### PR TITLE
Add hex 2-byte checksum support and Handshake.None RTS/DTR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,7 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# Local agent plans/specs (do not commit)
+.cursor/plans/
+.cursor/specs/

--- a/Demo/DemoHexProtocol.cs
+++ b/Demo/DemoHexProtocol.cs
@@ -13,8 +13,8 @@ namespace Demo
         {
             this.Mask = new byte[] { 0xAA, 0xBB, 0xCC };
             this.TimeOut = 5;//超过5秒，收不到数据，则此数据无效。
-            //自定义校验方法，演示为逐个相加和随便一个数字取模，我选择的是42
-            this.CheckData = SumCheck; // 使用BinaryProtocolAnalyzer提供的和校验方法
+            // 默认 CheckLength = 1（单字节校验）。双字节时设置 CheckLength = 2 并指定 CheckData16。
+            this.CheckData = SumCheck; // 使用 HexProtocolAnalyzer 提供的和校验方法
         }
         /// <summary>
         /// 数据解析协议

--- a/KoboldCom/CheckSumHandler.cs
+++ b/KoboldCom/CheckSumHandler.cs
@@ -10,4 +10,13 @@ namespace KoboldCom
     /// <param name="length">数据长度</param>
     /// <returns>校验方法计算结果</returns>
     public delegate byte CheckDataHandler(List<byte> buff, int i, int length);
+
+    /// <summary>
+    /// 双字节校验方法委托。返回 16 位校验值（主机数值，比较时再按大小端还原）。
+    /// </summary>
+    /// <param name="buff">要检验的数据</param>
+    /// <param name="i">起始位置</param>
+    /// <param name="length">数据长度</param>
+    /// <returns>16 位校验计算结果</returns>
+    public delegate int CheckData16Handler(List<byte> buff, int i, int length);
 }

--- a/KoboldCom/HexProtocolAnalyzer.cs
+++ b/KoboldCom/HexProtocolAnalyzer.cs
@@ -13,7 +13,12 @@ namespace KoboldCom
         /// 数据校验，默认使用异或校验
         /// </summary>
         protected CheckDataHandler CheckData;
+        /// <summary>
+        /// 双字节校验。CheckLength 为 2 时优先使用；未设置则把 CheckData 的单字节结果按 16 位值比较。
+        /// </summary>
+        protected CheckData16Handler CheckData16;
         private int _stickLength;//定长数据-数据中不含数据长度的情况
+        private int _checkLength;
 
         /// <summary>
         /// 构造函数 Protected
@@ -24,6 +29,7 @@ namespace KoboldCom
             CheckData = new CheckDataHandler(HexProtocolAnalyzer<T>.XorCheck);
             _stickLength = 0;//置为0：默认非定长数据
             LenLength = 1;
+            CheckLength = 1;
         }
 
         /// <summary>
@@ -83,14 +89,14 @@ namespace KoboldCom
                     }
 
                     // 判断Buff中的数据是否够一个数据包, 如果不够：返回数据头标志，等待buff继续缓存新数据
-                    if (buffer.Count - index - (Mask.Length + LenLength) - 1 < dataLength)//-1是减去校验位
+                    if (buffer.Count - index - (Mask.Length + LenLength) - CheckLength < dataLength)
                     {
                         return SearchResult.Mask;
                     }
+                    int dataIndex = (index + Mask.Length) + LenLength;
+                    int checkIndex = index + (Mask.Length + dataLength) + LenLength;
                     //-数据校验
-                    if ((CheckData != null) && //--存在校验方法
-                        (CheckData(buffer, (index + Mask.Length) + LenLength, dataLength) //--数据长度
-                         != buffer[index + (Mask.Length + dataLength) + LenLength]))
+                    if (!ChecksumMatches(buffer, dataIndex, dataLength, checkIndex))
                     {
                         Console.WriteLine(index + "-" + buffer.Count + "-" + maskIndex);
                         // 对于校验不符合要求的数据，继续向后搜寻。(数据头是协议中定义出来的特异标志肯定不会出现在数据中)
@@ -99,7 +105,7 @@ namespace KoboldCom
                     }
                     else
                     {
-                        int count = ((Mask.Length + 1) + dataLength) + LenLength;//数据包总长度
+                        int count = ((Mask.Length + CheckLength) + dataLength) + LenLength;//数据包总长度
                         //拷贝数据包到Raw，然后以该数据包为分界点，清除buffer中匹配过的数据
                         Raw = new byte[count];
                         Console.WriteLine(index + "~~" + count);
@@ -142,6 +148,78 @@ namespace KoboldCom
         }
 
         /// <summary>
+        /// 16 位累加和（取低 16 位）。配合 CheckLength = 2 使用。
+        /// </summary>
+        public static int SumCheck16(List<byte> buf, int index, int len)
+        {
+            int num = 0;
+            for (int i = index; i < (index + len); i++)
+            {
+                num = (num + buf[i]) & 0xFFFF;
+            }
+            return num;
+        }
+
+        /// <summary>
+        /// Modbus CRC-16（多项式 0xA001，初值 0xFFFF）。默认按小端与帧尾两字节比较。
+        /// </summary>
+        public static int Crc16Modbus(List<byte> buf, int index, int len)
+        {
+            int crc = 0xFFFF;
+            for (int i = index; i < (index + len); i++)
+            {
+                crc ^= buf[i];
+                for (int n = 0; n < 8; n++)
+                {
+                    if ((crc & 1) != 0)
+                    {
+                        crc = (crc >> 1) ^ 0xA001;
+                    }
+                    else
+                    {
+                        crc >>= 1;
+                    }
+                }
+            }
+            return crc & 0xFFFF;
+        }
+
+        private bool ChecksumMatches(List<byte> buffer, int dataIndex, int dataLength, int checkIndex)
+        {
+            if (CheckLength <= 0)
+            {
+                return true;
+            }
+            if (CheckLength == 1)
+            {
+                if (CheckData == null)
+                {
+                    return true;
+                }
+                return CheckData(buffer, dataIndex, dataLength) == buffer[checkIndex];
+            }
+
+            int computed;
+            if (CheckData16 != null)
+            {
+                computed = CheckData16(buffer, dataIndex, dataLength) & 0xFFFF;
+            }
+            else if (CheckData != null)
+            {
+                computed = CheckData(buffer, dataIndex, dataLength);
+            }
+            else
+            {
+                return true;
+            }
+
+            int expected = CheckBigEndian
+                ? ((buffer[checkIndex] << 8) | buffer[checkIndex + 1])
+                : (buffer[checkIndex] | (buffer[checkIndex + 1] << 8));
+            return computed == expected;
+        }
+
+        /// <summary>
         /// 定长数据长度-默认不含数据校验位
         /// </summary>
         public int StaticLength
@@ -154,6 +232,37 @@ namespace KoboldCom
         /// 数据长度值是几个字节的数据
         /// </summary>
         protected int LenLength { get; set; }
+
+        /// <summary>
+        /// 帧尾校验字节数。默认 1，保持现有单字节 XOR/SUM 协议兼容。
+        /// 设为 2 时按二进制双字节比较：默认小端（低字节在前，与 Modbus CRC-16 一致）；
+        /// 高字节在前的协议请设置 CheckBigEndian = true。
+        /// 小于等于 0 表示帧中不含校验段、也不做校验。其他正数按 2 处理。
+        /// </summary>
+        public int CheckLength
+        {
+            get { return _checkLength; }
+            set
+            {
+                if (value == 1)
+                {
+                    _checkLength = 1;
+                }
+                else if (value <= 0)
+                {
+                    _checkLength = 0;
+                }
+                else
+                {
+                    _checkLength = 2;
+                }
+            }
+        }
+
+        /// <summary>
+        /// CheckLength 为 2 时，帧尾两字节是否按大端（高字节在前）解释。默认 false（小端）。
+        /// </summary>
+        public bool CheckBigEndian { get; set; }
 
         /// <summary>
         /// 数据头

--- a/KoboldCom/SerialPort.cs
+++ b/KoboldCom/SerialPort.cs
@@ -183,15 +183,16 @@ namespace KoboldCom
         }
 
         /// <summary>
-        /// 获取或设置配置信息
+        /// 获取或设置配置信息。
+        /// Handshake 为 None 时读写 RtsEnable/DtrEnable；其他握手模式这两项不生效，读取为 false。
         /// </summary>
         public ICommunicationSetting Setting
         {
             get
             {
                 Handshake handshake = this._serialPort.Handshake;
-                bool rtsEnable = true;
-                bool dtrEnable = true;
+                bool rtsEnable = false;
+                bool dtrEnable = false;
                 if (handshake == Handshake.None)
                 {
                     rtsEnable = this._serialPort.RtsEnable;

--- a/KoboldCom/SerialPort.cs
+++ b/KoboldCom/SerialPort.cs
@@ -51,6 +51,7 @@ namespace KoboldCom
             try
             {
                 this._serialPort.Open();
+                ApplyControlLines(this._serialPort, setting);
                 this._serialPort.DataReceived += new SerialDataReceivedEventHandler(this.SerialPortDataReceived);
             }
             catch
@@ -188,14 +189,24 @@ namespace KoboldCom
         {
             get
             {
+                Handshake handshake = this._serialPort.Handshake;
+                bool rtsEnable = true;
+                bool dtrEnable = true;
+                if (handshake == Handshake.None)
+                {
+                    rtsEnable = this._serialPort.RtsEnable;
+                    dtrEnable = this._serialPort.DtrEnable;
+                }
                 return new SerialPortSetting
                 {
                     StopBits = this._serialPort.StopBits,
                     Baudrate = this._serialPort.BaudRate,
-                    Handshake = this._serialPort.Handshake,
+                    Handshake = handshake,
                     NewLine = this._serialPort.NewLine,
                     Parity = this._serialPort.Parity,
-                    Port = int.Parse(Regex.Match(this._serialPort.PortName, @"\d+").Value)
+                    Port = int.Parse(Regex.Match(this._serialPort.PortName, @"\d+").Value),
+                    RtsEnable = rtsEnable,
+                    DtrEnable = dtrEnable
                 };
             }
             set
@@ -212,7 +223,22 @@ namespace KoboldCom
                 this._serialPort.Handshake = setting.Handshake;
                 this._serialPort.BaudRate = setting.Baudrate;
                 this._serialPort.StopBits = setting.StopBits;
+                ApplyControlLines(this._serialPort, setting);
             }
+        }
+
+        /// <summary>
+        /// Handshake.None 时写入 RTS/DTR。部分 USB 转串口只在 Open 之后才真正拉线。
+        /// Handshake 不为 None 时不可设置这两项（会抛 InvalidOperationException）。
+        /// </summary>
+        private static void ApplyControlLines(System.IO.Ports.SerialPort port, SerialPortSetting setting)
+        {
+            if ((setting == null) || (setting.Handshake != Handshake.None))
+            {
+                return;
+            }
+            port.RtsEnable = setting.RtsEnable;
+            port.DtrEnable = setting.DtrEnable;
         }
     }
 }

--- a/KoboldCom/SerialPortSetting.cs
+++ b/KoboldCom/SerialPortSetting.cs
@@ -22,6 +22,8 @@ namespace KoboldCom
             this.Parity = Parity.None;
             this.Handshake = Handshake.None;
             this.NewLine = "\r\n";
+            this.RtsEnable = true;
+            this.DtrEnable = true;
         }
 
         /// <summary>
@@ -63,6 +65,18 @@ namespace KoboldCom
         /// 握手协议
         /// </summary>
         public Handshake Handshake;
+
+        /// <summary>
+        /// Handshake 为 None 时是否拉高 RTS。默认 true，避免无硬件握手设备在 Write 后收不到应答。
+        /// Handshake 不为 None 时由系统握手逻辑控制 RTS，本属性不生效。
+        /// </summary>
+        public bool RtsEnable;
+
+        /// <summary>
+        /// Handshake 为 None 时是否拉高 DTR。默认 true。
+        /// Handshake 不为 None 时由系统握手逻辑控制 DTR，本属性不生效。
+        /// </summary>
+        public bool DtrEnable;
 
         /// <summary>
         /// 新行标识

--- a/README.EN.md
+++ b/README.EN.md
@@ -14,6 +14,13 @@ HexProtocolAnalyzer still defaults to a **1-byte** trailing checksum (`XorCheck`
 
 When `Handshake` is `None`, `SerialPortSetting` defaults `RtsEnable` and `DtrEnable` to `true` and applies them on `Open` / `Setting`. Hardware that uses a real handshake mode is unchanged.
 
+No hardware required:
+
+```
+dotnet run --project verify/HexProtocolAnalyzerCheckLength
+dotnet run --project verify/SerialPortHandshakeNone
+```
+
 
 ### Code Demo
 See `/Demo` does

--- a/README.EN.md
+++ b/README.EN.md
@@ -4,9 +4,15 @@ KoboldCom is serial port communication lib.
 
 Support Custom protocol, async data receive handler and analyzer.
 
+“Async” here means the `SerialPort.DataReceived` event-driven receive/parse pipeline, not C# `async`/`await`.
+
 Support basic HexProtocolAnalyzer and TextProtocolAnalyzer. So you can implement a protocol quickly.
 
 TextProtocolAnalyzer can optionally validate checksums via `CheckData` (same delegate as hex protocols). In a subclass constructor, for NMEA-style `$...*HH`, set `BeginOfLine = "$"`, `EndOfLine = "*"`, and `CheckData = XorCheck`. `CheckLength` defaults to 2 hex ASCII digits after `EndOfLine`. Leave `CheckData` unset to keep existing no-checksum text protocols unchanged. `EndOfLine` is searched after `BeginOfLine`. Complete frames with a bad checksum are discarded from the buffer and are not treated as valid packets.
+
+HexProtocolAnalyzer still defaults to a **1-byte** trailing checksum (`XorCheck`). For a 2-byte binary checksum, set `CheckLength = 2` and `CheckData16` (`Crc16Modbus` or `SumCheck16`). The 16-bit value is compared to the last two bytes in **little-endian** order by default (Modbus CRC-16). Set `CheckBigEndian = true` for high-byte-first frames.
+
+When `Handshake` is `None`, `SerialPortSetting` defaults `RtsEnable` and `DtrEnable` to `true` and applies them on `Open` / `Setting`. Hardware that uses a real handshake mode is unchanged.
 
 
 ### Code Demo

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ CheckData16 = Crc16Modbus; // 或 SumCheck16；返回 16 位主机数值
 ```
 dotnet run --project verify/TextProtocolAnalyzerCheckData
 dotnet run --project verify/HexProtocolAnalyzerCheckLength
+dotnet run --project verify/SerialPortHandshakeNone
 ```
 
 ### 串口 RTS / DTR

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 `KoboldCom`是一个串口通信类库，提供自定义多协议异步解析、数据模型转换等功能。
 
+这里的「异步」指 `SerialPort.DataReceived` 事件驱动的收包与解析流水线，不是 C# 的 `async`/`await`。
+
 封装最复杂的数据流异步收发，以及根据协议把接收的数据进行模型映射转换等功能。
 
 类库提供了常见的16进制字节流协议`(HexProtocolAnalyzer)`和文本字节串协议`(TextProtocolAnalyzer)`的解析，所以可以使用KoboldCom，快速实现指定协议的数据收发
@@ -32,7 +34,25 @@ CheckData = XorCheck; // 默认读取 * 后 2 位十六进制，与 $ 和 * 之�
 校验失败的完整帧不会当作有效数据包，并从缓冲区丢弃；若其后还有合法帧，会继续匹配。
 `CheckLength` 默认为 2（十六进制 ASCII）；设为 1 时按 `EndOfLine` 后的单字节二进制校验比较。
 
-无硬件校验可运行：`dotnet run --project verify/TextProtocolAnalyzerCheckData`
+十六进制协议默认仍是帧尾 **1 字节**校验（`XorCheck`），现有协议无需改动。双字节校验时在子类构造函数中设置：
+
+```
+CheckLength = 2;
+CheckData16 = Crc16Modbus; // 或 SumCheck16；返回 16 位主机数值
+// 默认按小端（低字节在前）与帧尾两字节比较，与 Modbus CRC-16 一致
+// 高字节在前时：CheckBigEndian = true;
+```
+
+未设置 `CheckData16` 时，会把原来的单字节 `CheckData` 结果当作 16 位值比较。无硬件校验可运行：
+
+```
+dotnet run --project verify/TextProtocolAnalyzerCheckData
+dotnet run --project verify/HexProtocolAnalyzerCheckLength
+```
+
+### 串口 RTS / DTR
+
+`Handshake.None` 时，系统不会自动驱动 RTS/DTR。`SerialPortSetting` 默认 `RtsEnable = true`、`DtrEnable = true`，在 `Open` / 应用 `Setting` 时写入端口，避免部分设备只能被动收数、`Write` 后无应答。需要关闭时把对应标志设为 `false`。`Handshake` 不为 `None` 时仍由系统握手逻辑控制，不会改写这两根线。
 
 ### Demo
 ![运行截图](/docs/Screen01.png)

--- a/verify/HexProtocolAnalyzerCheckLength/HexProtocolAnalyzerCheckLength.csproj
+++ b/verify/HexProtocolAnalyzerCheckLength/HexProtocolAnalyzerCheckLength.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <OutputPath>../../obj/verify-hex/</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\KoboldCom\HexProtocolAnalyzer.cs" />
+    <Compile Include="..\..\KoboldCom\ProtocolAnalyzer.cs" />
+    <Compile Include="..\..\KoboldCom\CheckSumHandler.cs" />
+    <Compile Include="..\..\KoboldCom\SearchResult.cs" />
+    <Compile Include="..\..\KoboldCom\IAnalyzer.cs" />
+  </ItemGroup>
+</Project>

--- a/verify/HexProtocolAnalyzerCheckLength/Program.cs
+++ b/verify/HexProtocolAnalyzerCheckLength/Program.cs
@@ -21,6 +21,9 @@ namespace HexProtocolAnalyzerCheckLength
             Crc16ModbusLittleEndianIsAccepted();
             StaticLengthTwoByteFrameIsAccepted();
             CheckLengthDefaultsToOne();
+            OneByteIncompleteWaits();
+            TwoByteFallsBackToSingleByteCheckData();
+            CheckLengthZeroOmitsChecksumBytes();
 
             if (_failures > 0)
             {
@@ -144,6 +147,37 @@ namespace HexProtocolAnalyzerCheckLength
             Expect("default CheckLength", 1, p.PublicCheckLength);
         }
 
+        private static void OneByteIncompleteWaits()
+        {
+            DefaultXorProtocol p = new DefaultXorProtocol();
+            List<byte> buffer = Bytes(0xAA, 0x02, 0x01, 0x02);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("xor1 incomplete result", SearchResult.Mask, result);
+            Expect("xor1 incomplete raw", 0, p.Raw.Length);
+            Expect("xor1 incomplete kept", 4, buffer.Count);
+        }
+
+        private static void TwoByteFallsBackToSingleByteCheckData()
+        {
+            ByteCheckAs16Protocol p = new ByteCheckAs16Protocol();
+            // xor(01,02)=03 compared as 16-bit LE => 03 00
+            List<byte> buffer = Bytes(0xAA, 0x02, 0x01, 0x02, 0x03, 0x00);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("byte16 result", SearchResult.All, result);
+            Expect("byte16 raw", "AA0201020300", Hex(p.Raw));
+        }
+
+        private static void CheckLengthZeroOmitsChecksumBytes()
+        {
+            NoChecksumProtocol p = new NoChecksumProtocol();
+            List<byte> buffer = Bytes(0xAA, 0x02, 0x01, 0x02, 0x99);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("nocheck result", SearchResult.All, result);
+            Expect("nocheck raw", "AA020102", Hex(p.Raw));
+            Expect("nocheck leftover", 1, buffer.Count);
+            Expect("nocheck leftover byte", 0x99, buffer[0]);
+        }
+
         private static List<byte> Bytes(params byte[] values)
         {
             return new List<byte>(values);
@@ -251,6 +285,34 @@ namespace HexProtocolAnalyzerCheckLength
                 StaticLength = 3;
                 CheckLength = 2;
                 CheckData16 = SumCheck16;
+            }
+
+            public override void Analyze()
+            {
+            }
+        }
+
+        private sealed class ByteCheckAs16Protocol : HexProtocolAnalyzer<int>
+        {
+            public ByteCheckAs16Protocol()
+            {
+                Mask = new byte[] { 0xAA };
+                CheckLength = 2;
+                CheckData = XorCheck;
+            }
+
+            public override void Analyze()
+            {
+            }
+        }
+
+        private sealed class NoChecksumProtocol : HexProtocolAnalyzer<int>
+        {
+            public NoChecksumProtocol()
+            {
+                Mask = new byte[] { 0xAA };
+                CheckLength = 0;
+                CheckData = null;
             }
 
             public override void Analyze()

--- a/verify/HexProtocolAnalyzerCheckLength/Program.cs
+++ b/verify/HexProtocolAnalyzerCheckLength/Program.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using KoboldCom;
+
+namespace HexProtocolAnalyzerCheckLength
+{
+    internal static class Program
+    {
+        private static int _failures;
+
+        private static int Main()
+        {
+            DefaultOneByteXorIsAccepted();
+            DefaultOneByteXorRejectsBadChecksum();
+            DemoLikeSumCheckFrameIsAccepted();
+            TwoByteLittleEndianSumIsAccepted();
+            TwoByteBigEndianSumIsAccepted();
+            TwoByteLittleEndianRejectsSwappedBytes();
+            TwoByteIncompleteWaits();
+            InvalidThenValidTwoByteFindsValid();
+            Crc16ModbusLittleEndianIsAccepted();
+            StaticLengthTwoByteFrameIsAccepted();
+            CheckLengthDefaultsToOne();
+
+            if (_failures > 0)
+            {
+                Console.WriteLine("FAILED: {0} check(s)", _failures);
+                return 1;
+            }
+
+            Console.WriteLine("All HexProtocolAnalyzer CheckLength checks passed.");
+            return 0;
+        }
+
+        private static void DefaultOneByteXorIsAccepted()
+        {
+            DefaultXorProtocol p = new DefaultXorProtocol();
+            // AA | len=2 | 01 02 | xor(01,02)=03
+            List<byte> buffer = Bytes(0xAA, 0x02, 0x01, 0x02, 0x03);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("xor1 result", SearchResult.All, result);
+            Expect("xor1 raw", "AA02010203", Hex(p.Raw));
+            Expect("xor1 leftover", 0, buffer.Count);
+        }
+
+        private static void DefaultOneByteXorRejectsBadChecksum()
+        {
+            DefaultXorProtocol p = new DefaultXorProtocol();
+            List<byte> buffer = Bytes(0xAA, 0x02, 0x01, 0x02, 0xFF);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("xor1 bad result", SearchResult.None, result);
+            Expect("xor1 bad raw", 0, p.Raw.Length);
+        }
+
+        private static void DemoLikeSumCheckFrameIsAccepted()
+        {
+            DemoLikeProtocol p = new DemoLikeProtocol();
+            // AA BB CC | 08 | 12 00 00 00 24 00 00 00 | 36
+            List<byte> buffer = Bytes(
+                0xAA, 0xBB, 0xCC, 0x08,
+                0x12, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00, 0x00,
+                0x36);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("demo result", SearchResult.All, result);
+            Expect("demo raw length", 13, p.Raw.Length);
+            Expect("demo check", 0x36, p.Raw[12]);
+        }
+
+        private static void TwoByteLittleEndianSumIsAccepted()
+        {
+            TwoByteLeProtocol p = new TwoByteLeProtocol();
+            // AA | 03 | 01 02 03 | sum16=0006 LE => 06 00
+            List<byte> buffer = Bytes(0xAA, 0x03, 0x01, 0x02, 0x03, 0x06, 0x00);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("sum16le result", SearchResult.All, result);
+            Expect("sum16le raw", "AA030102030600", Hex(p.Raw));
+            Expect("sum16le leftover", 0, buffer.Count);
+        }
+
+        private static void TwoByteBigEndianSumIsAccepted()
+        {
+            TwoByteBeProtocol p = new TwoByteBeProtocol();
+            // AA | 03 | 01 02 03 | sum16=0006 BE => 00 06
+            List<byte> buffer = Bytes(0xAA, 0x03, 0x01, 0x02, 0x03, 0x00, 0x06);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("sum16be result", SearchResult.All, result);
+            Expect("sum16be raw", "AA030102030006", Hex(p.Raw));
+        }
+
+        private static void TwoByteLittleEndianRejectsSwappedBytes()
+        {
+            TwoByteLeProtocol p = new TwoByteLeProtocol();
+            // BE layout must not match LE protocol
+            List<byte> buffer = Bytes(0xAA, 0x03, 0x01, 0x02, 0x03, 0x00, 0x06);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("sum16le swapped result", SearchResult.None, result);
+            Expect("sum16le swapped raw", 0, p.Raw.Length);
+        }
+
+        private static void TwoByteIncompleteWaits()
+        {
+            TwoByteLeProtocol p = new TwoByteLeProtocol();
+            List<byte> buffer = Bytes(0xAA, 0x03, 0x01, 0x02, 0x03, 0x06);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("incomplete result", SearchResult.Mask, result);
+            Expect("incomplete raw", 0, p.Raw.Length);
+            Expect("incomplete kept", 6, buffer.Count);
+        }
+
+        private static void InvalidThenValidTwoByteFindsValid()
+        {
+            TwoByteLeProtocol p = new TwoByteLeProtocol();
+            List<byte> buffer = Bytes(
+                0xAA, 0x03, 0x01, 0x02, 0x03, 0x00, 0x00,
+                0xAA, 0x03, 0x01, 0x02, 0x03, 0x06, 0x00);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("skip-bad result", SearchResult.All, result);
+            Expect("skip-bad raw", "AA030102030600", Hex(p.Raw));
+        }
+
+        private static void Crc16ModbusLittleEndianIsAccepted()
+        {
+            Crc16Protocol p = new Crc16Protocol();
+            // payload 01 03 00 00 00 0A , Modbus CRC = 0xCDC5, LE => C5 CD
+            List<byte> buffer = Bytes(0xAA, 0x06, 0x01, 0x03, 0x00, 0x00, 0x00, 0x0A, 0xC5, 0xCD);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("crc16 result", SearchResult.All, result);
+            Expect("crc16 raw ends", "C5CD", Hex(p.Raw).Substring(Hex(p.Raw).Length - 4));
+        }
+
+        private static void StaticLengthTwoByteFrameIsAccepted()
+        {
+            StaticTwoByteProtocol p = new StaticTwoByteProtocol();
+            // mask AA, 3 data bytes, LE sum16
+            List<byte> buffer = Bytes(0xAA, 0x01, 0x02, 0x03, 0x06, 0x00);
+            SearchResult result = p.SearchBuffer(buffer);
+            Expect("static result", SearchResult.All, result);
+            Expect("static raw", "AA0102030600", Hex(p.Raw));
+        }
+
+        private static void CheckLengthDefaultsToOne()
+        {
+            DefaultXorProtocol p = new DefaultXorProtocol();
+            Expect("default CheckLength", 1, p.PublicCheckLength);
+        }
+
+        private static List<byte> Bytes(params byte[] values)
+        {
+            return new List<byte>(values);
+        }
+
+        private static string Hex(byte[] data)
+        {
+            char[] hex = new char[data.Length * 2];
+            const string digits = "0123456789ABCDEF";
+            for (int i = 0; i < data.Length; i++)
+            {
+                hex[i * 2] = digits[data[i] >> 4];
+                hex[i * 2 + 1] = digits[data[i] & 0x0F];
+            }
+            return new string(hex);
+        }
+
+        private static void Expect<T>(string name, T expected, T actual)
+        {
+            if (!Equals(expected, actual))
+            {
+                _failures++;
+                Console.WriteLine("FAIL {0}: expected {1}, got {2}", name, expected, actual);
+            }
+        }
+
+        private sealed class DefaultXorProtocol : HexProtocolAnalyzer<int>
+        {
+            public DefaultXorProtocol()
+            {
+                Mask = new byte[] { 0xAA };
+            }
+
+            public int PublicCheckLength
+            {
+                get { return CheckLength; }
+            }
+
+            public override void Analyze()
+            {
+            }
+        }
+
+        private sealed class DemoLikeProtocol : HexProtocolAnalyzer<int>
+        {
+            public DemoLikeProtocol()
+            {
+                Mask = new byte[] { 0xAA, 0xBB, 0xCC };
+                CheckData = SumCheck;
+            }
+
+            public override void Analyze()
+            {
+            }
+        }
+
+        private sealed class TwoByteLeProtocol : HexProtocolAnalyzer<int>
+        {
+            public TwoByteLeProtocol()
+            {
+                Mask = new byte[] { 0xAA };
+                CheckLength = 2;
+                CheckData16 = SumCheck16;
+            }
+
+            public override void Analyze()
+            {
+            }
+        }
+
+        private sealed class TwoByteBeProtocol : HexProtocolAnalyzer<int>
+        {
+            public TwoByteBeProtocol()
+            {
+                Mask = new byte[] { 0xAA };
+                CheckLength = 2;
+                CheckBigEndian = true;
+                CheckData16 = SumCheck16;
+            }
+
+            public override void Analyze()
+            {
+            }
+        }
+
+        private sealed class Crc16Protocol : HexProtocolAnalyzer<int>
+        {
+            public Crc16Protocol()
+            {
+                Mask = new byte[] { 0xAA };
+                CheckLength = 2;
+                CheckData16 = Crc16Modbus;
+            }
+
+            public override void Analyze()
+            {
+            }
+        }
+
+        private sealed class StaticTwoByteProtocol : HexProtocolAnalyzer<int>
+        {
+            public StaticTwoByteProtocol()
+            {
+                Mask = new byte[] { 0xAA };
+                StaticLength = 3;
+                CheckLength = 2;
+                CheckData16 = SumCheck16;
+            }
+
+            public override void Analyze()
+            {
+            }
+        }
+    }
+}

--- a/verify/SerialPortHandshakeNone/Program.cs
+++ b/verify/SerialPortHandshakeNone/Program.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO.Ports;
+using KoboldCom;
+using SerialPort = KoboldCom.SerialPort;
+
+namespace SerialPortHandshakeNone
+{
+    internal static class Program
+    {
+        private static int _failures;
+
+        private static int Main()
+        {
+            SettingDefaultsEnableRtsDtr();
+            HandshakeNoneAppliesRtsDtr();
+            HandshakeNoneHonorsDisabledFlags();
+            RequestToSendDoesNotThrow();
+
+            if (_failures > 0)
+            {
+                Console.WriteLine("FAILED: {0} check(s)", _failures);
+                return 1;
+            }
+
+            Console.WriteLine("All SerialPort Handshake.None RTS/DTR checks passed.");
+            return 0;
+        }
+
+        private static void SettingDefaultsEnableRtsDtr()
+        {
+            SerialPortSetting setting = new SerialPortSetting();
+            Expect("default handshake", Handshake.None, setting.Handshake);
+            Expect("default RtsEnable", true, setting.RtsEnable);
+            Expect("default DtrEnable", true, setting.DtrEnable);
+        }
+
+        private static void HandshakeNoneAppliesRtsDtr()
+        {
+            SerialPort port = new SerialPort();
+            port.Setting = new SerialPortSetting
+            {
+                Port = 1,
+                Handshake = Handshake.None,
+                RtsEnable = true,
+                DtrEnable = true
+            };
+            SerialPortSetting applied = (SerialPortSetting)port.Setting;
+            Expect("applied handshake", Handshake.None, applied.Handshake);
+            Expect("applied RtsEnable", true, applied.RtsEnable);
+            Expect("applied DtrEnable", true, applied.DtrEnable);
+        }
+
+        private static void HandshakeNoneHonorsDisabledFlags()
+        {
+            SerialPort port = new SerialPort();
+            port.Setting = new SerialPortSetting
+            {
+                Port = 1,
+                Handshake = Handshake.None,
+                RtsEnable = false,
+                DtrEnable = false
+            };
+            SerialPortSetting applied = (SerialPortSetting)port.Setting;
+            Expect("disabled RtsEnable", false, applied.RtsEnable);
+            Expect("disabled DtrEnable", false, applied.DtrEnable);
+        }
+
+        private static void RequestToSendDoesNotThrow()
+        {
+            SerialPort port = new SerialPort();
+            try
+            {
+                port.Setting = new SerialPortSetting
+                {
+                    Port = 1,
+                    Handshake = Handshake.RequestToSend,
+                    RtsEnable = true,
+                    DtrEnable = true
+                };
+                Expect("rts handshake", Handshake.RequestToSend, ((SerialPortSetting)port.Setting).Handshake);
+            }
+            catch (Exception ex)
+            {
+                _failures++;
+                Console.WriteLine("FAIL request-to-send throw: {0}", ex.GetType().Name);
+            }
+        }
+
+        private static void Expect<T>(string name, T expected, T actual)
+        {
+            if (!Equals(expected, actual))
+            {
+                _failures++;
+                Console.WriteLine("FAIL {0}: expected {1}, got {2}", name, expected, actual);
+            }
+        }
+    }
+}

--- a/verify/SerialPortHandshakeNone/Program.cs
+++ b/verify/SerialPortHandshakeNone/Program.cs
@@ -11,10 +11,12 @@ namespace SerialPortHandshakeNone
 
         private static int Main()
         {
+            // Settings-only: does not Open a real COM port. ApplyControlLines is the same helper used after Open.
             SettingDefaultsEnableRtsDtr();
             HandshakeNoneAppliesRtsDtr();
             HandshakeNoneHonorsDisabledFlags();
             RequestToSendDoesNotThrow();
+            RequestToSendReportsControlLinesInactive();
 
             if (_failures > 0)
             {
@@ -84,6 +86,21 @@ namespace SerialPortHandshakeNone
                 _failures++;
                 Console.WriteLine("FAIL request-to-send throw: {0}", ex.GetType().Name);
             }
+        }
+
+        private static void RequestToSendReportsControlLinesInactive()
+        {
+            SerialPort port = new SerialPort();
+            port.Setting = new SerialPortSetting
+            {
+                Port = 1,
+                Handshake = Handshake.RequestToSend,
+                RtsEnable = true,
+                DtrEnable = true
+            };
+            SerialPortSetting applied = (SerialPortSetting)port.Setting;
+            Expect("rts mode RtsEnable inactive", false, applied.RtsEnable);
+            Expect("rts mode DtrEnable inactive", false, applied.DtrEnable);
         }
 
         private static void Expect<T>(string name, T expected, T actual)

--- a/verify/SerialPortHandshakeNone/SerialPortHandshakeNone.csproj
+++ b/verify/SerialPortHandshakeNone/SerialPortHandshakeNone.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <OutputPath>../../obj/verify-serial/</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.IO.Ports" Version="8.0.0" />
+    <Compile Include="..\..\KoboldCom\SerialPort.cs" />
+    <Compile Include="..\..\KoboldCom\SerialPortSetting.cs" />
+    <Compile Include="..\..\KoboldCom\ICommunication.cs" />
+    <Compile Include="..\..\KoboldCom\ICommunicationSetting.cs" />
+    <Compile Include="..\..\KoboldCom\DataReceivedHandler.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Closes two long-standing gaps that were discussed on closed issues but never shipped in the library.

**Issues reopened** (they were closed without library changes): [#1](https://github.com/PeterRock/KoboldCom/issues/1), [#2](https://github.com/PeterRock/KoboldCom/issues/2), [#3](https://github.com/PeterRock/KoboldCom/issues/3), each with a maintainer note. This PR is the remaining work.

### Hex 2-byte checksum (`Fixes #1`)
`HexProtocolAnalyzer` no longer hard-codes a single trailing check byte. It now has a `CheckLength` property in the same style as `TextProtocolAnalyzer`:

- **Default `CheckLength = 1`** — existing 1-byte XOR/SUM protocols are unchanged.
- **`CheckLength = 2`** — the last two bytes are a 16-bit checksum. Assign `CheckData16` (`Crc16Modbus` or `SumCheck16`, or a custom `CheckData16Handler`).
- Comparison is **little-endian by default** (low byte first), matching Modbus CRC-16 and most industrial serial frames. Set `CheckBigEndian = true` for high-byte-first protocols.
- If `CheckData16` is unset, the original 1-byte `CheckData` result is compared as a 16-bit value (high byte expected `0`).
- `CheckLength <= 0` means the frame has no checksum field.

```csharp
public class ModbusLike : HexProtocolAnalyzer<MyModel>
{
    public ModbusLike()
    {
        Mask = new byte[] { 0xAA };
        CheckLength = 2;
        CheckData16 = Crc16Modbus; // little-endian C5 CD for CRC 0xCDC5
    }
}
```

### RTS/DTR when Handshake is None (`Fixes #3`)
`SerialPortSetting` now defaults `RtsEnable` and `DtrEnable` to `true`. They are applied on `Setting` and again after `Open` (some USB adapters only honor the lines once the port is open).

When `Handshake != None`, the flags are **not** written, so hardware handshake behavior is unchanged. The `Setting` getter reports those flags as inactive (`false`) in handshake modes. Set either flag to `false` if a no-handshake device must keep that line low.

### Docs (`Refs #2`)
README notes that “async” means the `SerialPort.DataReceived` event-driven pipeline, not C# `async`/`await`.

## Verification
Library stays on .NET Framework 3.5 (current master). Console checks compile the relevant sources on `net8.0`, same pattern as the text-protocol verify:

```bash
dotnet run --project verify/HexProtocolAnalyzerCheckLength
dotnet run --project verify/SerialPortHandshakeNone
dotnet run --project verify/TextProtocolAnalyzerCheckData
```

Hex checks cover: default 1-byte XOR (accept/reject/incomplete wait), demo-style SUM, 2-byte LE/BE sum, swapped-endian reject, incomplete 2-byte wait, invalid-then-valid, Modbus CRC-16 LE, static-length 2-byte frames, `CheckData`-only 16-bit fallback, `CheckLength = 0`, and default `CheckLength == 1`.

Serial checks cover: setting defaults, Handshake.None apply/disable, RequestToSend not throwing, and handshake modes reporting RTS/DTR as inactive. The serial harness is settings-only (does not open a physical COM port); after-`Open` uses the same `ApplyControlLines` helper.

## Test plan
- [x] `dotnet run --project verify/HexProtocolAnalyzerCheckLength`
- [x] `dotnet run --project verify/SerialPortHandshakeNone`
- [x] `dotnet run --project verify/TextProtocolAnalyzerCheckData` (regression)
- [ ] Optional hardware: Handshake.None device answers after `Write` without manually setting RTS/DTR
- [ ] Optional hardware: existing 1-byte hex protocol still parses

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abd98229-c5d6-4d4b-bf04-28b43b5cbab3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abd98229-c5d6-4d4b-bf04-28b43b5cbab3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

