### PR TITLE
Reorganize README docs for 2.0.0 / net8.0

### DIFF
--- a/README.EN.md
+++ b/README.EN.md
@@ -1,55 +1,180 @@
-[中文](/README.md)
-### KoboldCom
-KoboldCom is serial port communication lib.
+[中文](README.md)
 
-Support Custom protocol, async data receive handler and analyzer.
+# KoboldCom
 
-“Async” here means the `SerialPort.DataReceived` event-driven receive/parse pipeline, not C# `async`/`await`.
+KoboldCom is a C# serial-port library: receive bytes, match one or more protocols, and map complete frames onto your data models.
 
-Support basic HexProtocolAnalyzer and TextProtocolAnalyzer. So you can implement a protocol quickly.
+“Async” here means the `SerialPort.DataReceived` event-driven receive/parse pipeline, **not** C# `async` / `await`.
 
-TextProtocolAnalyzer can optionally validate checksums via `CheckData` (same delegate as hex protocols). In a subclass constructor, for NMEA-style `$...*HH`, set `BeginOfLine = "$"`, `EndOfLine = "*"`, and `CheckData = XorCheck`. `CheckLength` defaults to 2 hex ASCII digits after `EndOfLine`. Leave `CheckData` unset to keep existing no-checksum text protocols unchanged. `EndOfLine` is searched after `BeginOfLine`. Complete frames with a bad checksum are discarded from the buffer and are not treated as valid packets.
+## Features
 
-HexProtocolAnalyzer still defaults to a **1-byte** trailing checksum (`XorCheck`). For a 2-byte binary checksum, set `CheckLength = 2` and `CheckData16` (`Crc16Modbus` or `SumCheck16`). The 16-bit value is compared to the last two bytes in **little-endian** order by default (Modbus CRC-16). Set `CheckBigEndian = true` for high-byte-first frames.
+- Serial open, read/write, and raw receive (`Communicator` + `SerialPort`)
+- Built-in `HexProtocolAnalyzer` (binary frames) and `TextProtocolAnalyzer` (begin/end text frames)
+- Several protocols on one port; each analyzer maps a frame to your model
+- Optional checksums: text `CheckData` (for example NMEA XOR); hex 1-byte or 2-byte (`CheckData` / `CheckData16`)
+- With `Handshake.None`, RTS/DTR default high so some no-handshake devices can answer `Write`
 
-When `Handshake` is `None`, `SerialPortSetting` defaults `RtsEnable` and `DtrEnable` to `true` and applies them on `Open` / `Setting`. Hardware that uses a real handshake mode is unchanged.
+## Requirements and versioning
 
-### Versioning
+The current mainline needs the [.NET 8 SDK](https://dotnet.microsoft.com/download). 2.0.0 is an intentional major-version break.
 
-This is an intentional major-version break:
+| Line | Target | Where to get it |
+| --- | --- | --- |
+| **1.x** | .NET Framework 3.5 | Tag [`v1.1.0`](https://github.com/PeterRock/KoboldCom/releases/tag/v1.1.0). If you also need the later 2-byte hex checksum and Handshake.None RTS/DTR work, use branch [`netfx-1.x`](https://github.com/PeterRock/KoboldCom/tree/netfx-1.x). Do not move a Framework app to 2.x. |
+| **2.x** (current) | `net8.0` + NuGet `System.IO.Ports` | Current `master`, assembly version **2.0.0**. Includes the 1.x protocol/serial behavior above. Framework 3.5 projects cannot reference 2.x. |
 
-- **1.x** — .NET Framework 3.5. Tag **`v1.1.0`** is the Framework snapshot taken when 2.0 was planned (PR #4 CheckData). PR #5 (hex 2-byte checksum / Handshake.None RTS/DTR) later landed on Framework master; use branch **`netfx-1.x`** if you cannot leave Framework.
-- **2.x** (current mainline) — `net8.0` + NuGet `System.IO.Ports`, assembly version **2.0.0**, including PR #4 / #5 behavior. Framework 3.5 projects cannot reference 2.x.
+The public C# API and Chinese XML docs are kept as stable as practical. See [CHANGELOG.md](CHANGELOG.md) for the finer points.
 
-Public C# API and Chinese XML docs are preserved as much as practical. This modernization does not rewrite protocol logic.
+Port names are still Windows-style `COM` + number (`SerialPortSetting.Port`). The Demo is `net8.0-windows` WinForms and runs on Windows only.
 
-### Build
+## Quick start
 
-Requires the [.NET 8 SDK](https://dotnet.microsoft.com/download).
-
-```
+```bash
 dotnet build KoboldCom.sln
+
 dotnet run --project verify/TextProtocolAnalyzerCheckData
 dotnet run --project verify/HexProtocolAnalyzerCheckLength
 dotnet run --project verify/SerialPortHandshakeNone
 ```
 
-The Demo project is `net8.0-windows` WinForms and should be run on Windows.
+The three `verify` projects need no hardware. They cover text checksums, hex checksum length, and Handshake.None RTS/DTR defaults.
 
-### Code Demo
-See `/Demo` does
+On Windows, open the Demo:
 
-#### Usage 
-```
-var communicator = new KoboldCom.Communicator(new KoboldCom.SerialPort(), new MyProtocols());
+```bash
+dotnet run --project Demo
 ```
 
-### TODO:
+Non-Windows machines can cross-compile the Demo (`EnableWindowsTargeting` is on) but cannot run the UI. Full multi-protocol usage is in [`Demo/`](Demo/).
+
+## Concepts
+
+The pipeline is:
+
+`SerialPort.DataReceived` → `Communicator` reads bytes → each `IAnalyzer.SearchBuffer` cuts a frame → `Analyze()` maps the model
+
+`Communicator` holds an `ICommunication` (usually `KoboldCom.SerialPort`) and an `IAnalyzerCollection`. Incoming bytes raise `OnRawDataReceived`, then every analyzer searches the buffer.
+
+Subscribe to these two events in application code:
+
+| Event | On | When |
+| --- | --- | --- |
+| `OnRawDataReceived` | `Communicator` | A chunk of raw bytes was just read |
+| `OnDataAnalyzed` | A concrete `ProtocolAnalyzer<T>` | The subclass sets `Valid = true` (or later timeout sets `Valid` back to `false`) |
+
+`ICommunication.OnDataReceived` is the lower-level “bytes available” hook. `Communicator` already handles it.
+
+```csharp
+var protocols = new MyProtocols();
+var communicator = new Communicator(new KoboldCom.SerialPort(), protocols);
+
+communicator.OnRawDataReceived += bytes => { /* raw bytes */ };
+protocols.ProtocolText.OnDataAnalyzed += m => { /* text model */ };
+protocols.ProtocolBinary.OnDataAnalyzed += m => { /* hex model */ };
+
+communicator.Com.Open(new SerialPortSetting { Port = 2, Baudrate = 9600 });
+```
+
+`SerialPortSetting` defaults to `Handshake = None`, `RtsEnable = true`, and `DtrEnable = true`. Those flags are written when `Setting` is applied and again after `Open`. If `Handshake` is not `None`, the OS handshake owns the lines; the library does not write them, and the getter reports them inactive. Set a flag to `false` if that line must stay low.
+
+## Protocols
+
+A typical binary frame looks like:
+
+```
+header + length + payload + checksum
+AA 44 05 01 02 03 04 05 EA
+```
+
+A typical text sentence looks like:
+
+```
+$GPGGA,121252.000,3937.3032,N,11611.6046,E,1,05,2.0,45.9,M,-5.7,M,,0000*75
+```
+
+`$` starts the sentence, `*` ends it, and `75` is the XOR of the characters between `$` and `*`. Those two shapes map to `HexProtocolAnalyzer` and `TextProtocolAnalyzer`. Configure framing in the subclass **constructor**, map `Raw` to `Data` in `Analyze()`, then set `Valid = true`.
+
+### Text: `TextProtocolAnalyzer`
+
+Frame: `[BeginOfLine][payload][EndOfLine]`, optionally plus checksum: `[EndOfLine][check]`.
+
+- Leave `CheckData` unset for no checksum (the Demo `^&100$$` protocol does this)
+- `EndOfLine` is searched **after** `BeginOfLine`, so an earlier leftover terminator is ignored
+- A complete frame with a bad checksum is not a valid packet and is dropped from the buffer; a later good frame can still match
+
+NMEA-style `$...*HH`:
+
+```csharp
+public class NmeaProtocol : TextProtocolAnalyzer<MyModel>
+{
+    public NmeaProtocol()
+    {
+        BeginOfLine = "$";
+        EndOfLine = "*";
+        CheckData = XorCheck; // CheckLength defaults to 2 hex ASCII digits after *
+    }
+
+    public override void Analyze() { /* Raw → Data; Valid = true; */ }
+}
+```
+
+`CheckLength = 1` compares one raw byte after `EndOfLine`. Edge cases live in `verify/TextProtocolAnalyzerCheckData`.
+
+### Hex: `HexProtocolAnalyzer`
+
+Frame: `[Mask][length][data][checksum]`. Defaults are `CheckLength = 1` and `CheckData = XorCheck`, so existing 1-byte XOR/SUM protocols stay the same.
+
+```csharp
+public class DemoHex : HexProtocolAnalyzer<DemoDataModel>
+{
+    public DemoHex()
+    {
+        Mask = new byte[] { 0xAA, 0xBB, 0xCC };
+        CheckData = SumCheck; // still a 1-byte trailer by default
+    }
+
+    public override void Analyze() { /* Raw → Data; Valid = true; */ }
+}
+```
+
+For a 2-byte checksum, set this in the subclass constructor:
+
+```csharp
+CheckLength = 2;
+CheckData16 = Crc16Modbus; // or SumCheck16; returns a 16-bit host value
+// Compared little-endian (low byte first) by default, matching Modbus CRC-16
+// High byte first: CheckBigEndian = true;
+```
+
+If `CheckData16` is unset, the 1-byte `CheckData` result is compared as a 16-bit value. `CheckLength <= 0` means the frame has no checksum field. Use `StaticLength` for fixed-length frames. Details: `verify/HexProtocolAnalyzerCheckLength` and `Demo/DemoHexProtocol.cs`.
+
+## Extending
+
+If neither built-in analyzer fits, subclass abstract `ProtocolAnalyzer<T>`:
+
+- Override `SearchBuffer` to cut one frame from the `List<byte>` into `Raw`, and remove consumed bytes from the buffer
+- Implement `Analyze()` for the model mapping
+
+`HexProtocolAnalyzer` and `TextProtocolAnalyzer` already implement `SearchBuffer`. Most apps only set framing/checksums and override `Analyze()`. Put several analyzers in your own `IAnalyzerCollection` (see `Demo/MyProtocols.cs`) to run them together.
+
+## Demo
+
+![Demo screenshot](docs/Screen01.png)
+
+The WinForms sample runs the text protocol `^&…$$` and the hex protocol `AA BB CC …` at the same time, and lists `OnDataAnalyzed` results. Source: [`Demo/`](Demo/).
+
+## Serial debug
+
+[Windows virtual serial ports and debugging](https://www.petershi.net/archives/2885)
+
+## TODO
+
 - i18n
 
-### Thanks
-[Article](http://blog.csdn.net/wuyazhe/article/details/5598945)
+## Thanks
 
+The idea started from [this article](http://blog.csdn.net/wuyazhe/article/details/5598945).
 
-### License
-MIT
+## License
+
+[MIT](LICENSE)

--- a/README.EN.md
+++ b/README.EN.md
@@ -2,73 +2,38 @@
 
 # KoboldCom
 
-KoboldCom is a C# serial port library. It reads bytes from a serial port, splits frames with one or more protocol analyzers, and maps a complete frame to a data model.
-
-The library includes `HexProtocolAnalyzer` for binary frames and `TextProtocolAnalyzer` for text frames that use start and end markers.
+KoboldCom is a C# serial port library. It opens a port, reads and writes bytes, splits frames with one or more protocols, and maps a complete frame to a data model. One port can run more than one protocol.
 
 In this documentation, “async” means receive and parse work driven by the `SerialPort.DataReceived` event. It does not mean C# `async` / `await`.
 
 ## Requirements
 
-The current version requires the [.NET 8 SDK](https://dotnet.microsoft.com/download). Version 2.0.0 changes the target framework.
+The current version requires the [.NET 8 SDK](https://dotnet.microsoft.com/download).
 
 | Version | Target | How to get it |
 | --- | --- | --- |
-| **1.x** | .NET Framework 3.5 | Tag [`v1.1.0`](https://github.com/PeterRock/KoboldCom/releases/tag/v1.1.0). For the later 2-byte hex checksum and RTS/DTR behavior when `Handshake` is `None`, use branch [`netfx-1.x`](https://github.com/PeterRock/KoboldCom/tree/netfx-1.x). Do not upgrade a Framework project to 2.x. |
-| **2.x** (current) | `net8.0` + NuGet `System.IO.Ports` | Current `master`. Assembly version **2.0.0**. Includes the 1.x protocol and serial behavior listed above. A .NET Framework 3.5 project cannot reference 2.x. |
+| **1.x** | .NET Framework 3.5 | Tag [`v1.1.0`](https://github.com/PeterRock/KoboldCom/releases/tag/v1.1.0). Later Framework commits are on branch [`netfx-1.x`](https://github.com/PeterRock/KoboldCom/tree/netfx-1.x). Do not upgrade a Framework project to 2.x. |
+| **2.x** (current) | `net8.0` + NuGet `System.IO.Ports` | Current `master`. Assembly version **2.0.0**. A .NET Framework 3.5 project cannot reference 2.x. |
 
-The public C# API and Chinese XML docs in 2.0.0 match 1.x. Protocol logic was not rewritten. See [CHANGELOG.md](CHANGELOG.md) for the full list of changes.
+See [CHANGELOG.md](CHANGELOG.md) for the list of changes.
 
-A port name is `COM` plus the port number (`SerialPortSetting.Port`). The Demo targets `net8.0-windows`. The Demo runs on Windows only.
+## Components
 
-## Build
-
-```bash
-dotnet build KoboldCom.sln
-```
-
-These checks do not need hardware:
-
-```bash
-dotnet run --project verify/TextProtocolAnalyzerCheckData
-dotnet run --project verify/HexProtocolAnalyzerCheckLength
-dotnet run --project verify/SerialPortHandshakeNone
-```
-
-The projects check text checksums, hex checksum length, and RTS/DTR defaults when `Handshake` is `None`.
-
-Run the Demo on Windows:
-
-```bash
-dotnet run --project Demo
-```
-
-Other systems can cross-compile the Demo (`EnableWindowsTargeting` is set) but cannot run the UI. Sample code is in [`Demo/`](Demo/).
-
-## How it works
-
-`Communicator` holds an `ICommunication` (usually `KoboldCom.SerialPort`) and an `IAnalyzerCollection`.
+- `Communicator`: connects the port and the analyzers. Reads bytes and dispatches them.
+- `SerialPort` (implements `ICommunication`): opens, closes, reads, and writes the port.
+- `ProtocolAnalyzer<T>`: maps one frame to model `T`. Built-in types: `HexProtocolAnalyzer` and `TextProtocolAnalyzer`.
+- `IAnalyzerCollection`: a set of analyzers. One `Communicator` can register more than one protocol.
 
 Processing order:
 
 1. `SerialPort.DataReceived` fires.
-2. `Communicator` reads the bytes.
-3. `Communicator` raises `OnRawDataReceived`.
-4. Each `IAnalyzer` in the collection calls `SearchBuffer`.
-5. After a complete frame is found, `Analyze()` runs.
-
-A port can register more than one analyzer.
+2. `Communicator` reads the bytes and raises `OnRawDataReceived`.
+3. Each analyzer in the collection calls `SearchBuffer`.
+4. After a complete frame is found, `Analyze()` runs.
 
 ## Usage
 
-### Events
-
-| Event | Type | When it runs |
-| --- | --- | --- |
-| `OnRawDataReceived` | `Communicator` | A chunk of raw bytes was read. |
-| `OnDataAnalyzed` | `ProtocolAnalyzer<T>` | The subclass sets `Valid` to `true`. After a timeout, `Valid` is set back to `false` and the event runs again. |
-
-`ICommunication.OnDataReceived` means the port has bytes to read. `Communicator` already subscribes to that event.
+Create an `IAnalyzerCollection` (see `Demo/MyProtocols.cs`). Pass it and a `SerialPort` to `Communicator`. Subscribe to events. Open the port.
 
 ```csharp
 var protocols = new MyProtocols();
@@ -81,87 +46,43 @@ protocols.ProtocolBinary.OnDataAnalyzed += m => { /* hex model */ };
 communicator.Com.Open(new SerialPortSetting { Port = 2, Baudrate = 9600 });
 ```
 
-Set the frame format in the subclass constructor. In `Analyze()`, assign `Raw` to `Data`, then set `Valid = true`.
+Set the frame format in the protocol subclass constructor. In `Analyze()`, assign `Raw` to `Data`, then set `Valid = true`.
 
-### Serial settings
+| Event | Type | When it runs |
+| --- | --- | --- |
+| `OnRawDataReceived` | `Communicator` | A chunk of raw bytes was read. |
+| `OnDataAnalyzed` | `ProtocolAnalyzer<T>` | The subclass sets `Valid` to `true`. After a timeout, `Valid` is set back to `false` and the event runs again. |
 
-`SerialPortSetting` defaults:
+`ICommunication.OnDataReceived` means the port has bytes to read. `Communicator` already subscribes to that event.
 
-- `Handshake = None`
-- `RtsEnable = true`
-- `DtrEnable = true`
+A port name is `COM` plus the port number (`SerialPortSetting.Port`). When `Handshake` is `None`, `RtsEnable` and `DtrEnable` default to `true` and are written when `Setting` is applied and after `Open`.
 
-RTS/DTR are written when `Setting` is applied. They are written again after `Open`. If `Handshake` is not `None`, the library does not write those lines. Reading the settings then reports both as `false`. To keep a line low, set the matching property to `false`.
+### Text protocol
 
-### `TextProtocolAnalyzer`
-
-Frame format: `[BeginOfLine][payload][EndOfLine]`. If `CheckData` is set, a checksum follows: `[EndOfLine][check]`.
-
-- If `CheckData` is `null`, there is no checksum check. The Demo text protocol `^&100$$` does not set `CheckData`.
-- `EndOfLine` is searched after `BeginOfLine`.
-- A complete frame with a bad checksum is not a valid packet. That frame is removed from the buffer. A later valid frame can still match.
-- `CheckLength` defaults to 2, meaning two hex ASCII digits after `EndOfLine`. `CheckLength = 1` compares the next raw byte.
-
-See `verify/TextProtocolAnalyzerCheckData`.
-
-### `HexProtocolAnalyzer`
-
-Frame format: `[Mask][length][data][checksum]`.
-
-- `CheckLength` defaults to 1.
-- `CheckData` defaults to `XorCheck`.
-- For `CheckLength = 2`, set `CheckData16` (`Crc16Modbus` or `SumCheck16`). The compare is little-endian (low byte first) by default. For big-endian, set `CheckBigEndian = true`.
-- If `CheckData16` is not set, the 1-byte `CheckData` result is compared as a 16-bit value.
-- `CheckLength <= 0` means the frame has no checksum field.
-- For a fixed-length frame, set `StaticLength`.
-
-See `verify/HexProtocolAnalyzerCheckLength` and `Demo/DemoHexProtocol.cs`.
-
-### Custom protocols
-
-If the built-in analyzers do not apply, subclass `ProtocolAnalyzer<T>`.
-
-- Override `SearchBuffer`: copy one frame from the `List<byte>` into `Raw`, and remove the processed bytes from the buffer.
-- Override `Analyze()`: map `Raw` to the model.
-
-`HexProtocolAnalyzer` and `TextProtocolAnalyzer` already implement `SearchBuffer`. In that case, configure the subclass in the constructor and override `Analyze()`.
-
-Put more than one analyzer in an `IAnalyzerCollection`. Example: `Demo/MyProtocols.cs`.
-
-## Examples
-
-Binary frame:
-
-```
-header + length + payload + checksum
-AA 44 05 01 02 03 04 05 EA
-```
-
-Text frame:
-
-```
-$GPGGA,121252.000,3937.3032,N,11611.6046,E,1,05,2.0,45.9,M,-5.7,M,,0000*75
-```
-
-`$` is the start marker. `*` is the end marker. `75` is the XOR of the characters between `$` and `*`.
-
-NMEA (`$...*HH`):
+`TextProtocolAnalyzer` frame format: `[BeginOfLine][payload][EndOfLine]`. `EndOfLine` is searched after `BeginOfLine`.
 
 ```csharp
-public class NmeaProtocol : TextProtocolAnalyzer<MyModel>
+public class DemoText : TextProtocolAnalyzer<int>
 {
-    public NmeaProtocol()
+    public DemoText()
     {
-        BeginOfLine = "$";
-        EndOfLine = "*";
-        CheckData = XorCheck; // CheckLength defaults to 2
+        BeginOfLine = "^&";
+        EndOfLine = "$$";
     }
 
-    public override void Analyze() { /* Raw → Data; Valid = true; */ }
+    public override void Analyze() { /* parse Raw; Valid = true; */ }
 }
 ```
 
-Hex with a 1-byte sum:
+Optional checksum: if you set `CheckData`, a check field follows the frame. `CheckLength` defaults to 2 (two hex ASCII digits after `EndOfLine`). NMEA example: `BeginOfLine = "$"`, `EndOfLine = "*"`, `CheckData = XorCheck`. A complete frame with a bad checksum is removed from the buffer.
+
+### Hex protocol
+
+`HexProtocolAnalyzer` frame format: `[Mask][length][data][checksum]`. For a fixed-length frame, set `StaticLength`.
+
+```
+AA 44 05 01 02 03 04 05 EA
+```
 
 ```csharp
 public class DemoHex : HexProtocolAnalyzer<DemoDataModel>
@@ -169,26 +90,43 @@ public class DemoHex : HexProtocolAnalyzer<DemoDataModel>
     public DemoHex()
     {
         Mask = new byte[] { 0xAA, 0xBB, 0xCC };
-        CheckData = SumCheck; // CheckLength defaults to 1
+        CheckData = SumCheck;
     }
 
     public override void Analyze() { /* Raw → Data; Valid = true; */ }
 }
 ```
 
-Hex with a 2-byte checksum (set this in the subclass constructor):
+Optional checksum: `CheckLength` defaults to 1. `CheckData` defaults to `XorCheck`. For a 2-byte check, set `CheckLength = 2` and `CheckData16` (`Crc16Modbus` or `SumCheck16`). The compare is little-endian by default. For big-endian, set `CheckBigEndian = true`.
 
-```csharp
-CheckLength = 2;
-CheckData16 = Crc16Modbus; // or SumCheck16
-// Little-endian by default. Big-endian: CheckBigEndian = true;
-```
+## Custom protocols
+
+If the built-in analyzers do not apply, subclass `ProtocolAnalyzer<T>`.
+
+- Override `SearchBuffer`: copy one frame from the `List<byte>` into `Raw`, and remove the processed bytes from the buffer.
+- Override `Analyze()`: map `Raw` to the model.
+
+`HexProtocolAnalyzer` and `TextProtocolAnalyzer` already implement `SearchBuffer`. In that case, set the frame format and override `Analyze()`.
 
 ## Demo
 
 ![Demo screenshot](docs/Screen01.png)
 
-The Demo is a WinForms app. It parses the text protocol `^&…$$` and the hex protocol `AA BB CC …` and lists `OnDataAnalyzed` results. Source: [`Demo/`](Demo/).
+The Demo is a `net8.0-windows` WinForms app. It parses the text protocol `^&…$$` and the hex protocol `AA BB CC …` and lists `OnDataAnalyzed` results. Source: [`Demo/`](Demo/). Run it on Windows:
+
+```bash
+dotnet run --project Demo
+```
+
+Other systems can cross-compile the Demo (`EnableWindowsTargeting` is set) but cannot run the UI.
+
+## Build
+
+```bash
+dotnet build KoboldCom.sln
+```
+
+Checks that need no hardware: `dotnet run --project verify/TextProtocolAnalyzerCheckData`, `verify/HexProtocolAnalyzerCheckLength`, `verify/SerialPortHandshakeNone`.
 
 ## Additional resources
 

--- a/README.EN.md
+++ b/README.EN.md
@@ -2,67 +2,73 @@
 
 # KoboldCom
 
-KoboldCom is a C# serial-port library: receive bytes, match one or more protocols, and map complete frames onto your data models.
+KoboldCom is a C# serial port library. It reads bytes from a serial port, splits frames with one or more protocol analyzers, and maps a complete frame to a data model.
 
-“Async” here means the `SerialPort.DataReceived` event-driven receive/parse pipeline, **not** C# `async` / `await`.
+The library includes `HexProtocolAnalyzer` for binary frames and `TextProtocolAnalyzer` for text frames that use start and end markers.
 
-## Features
+In this documentation, “async” means receive and parse work driven by the `SerialPort.DataReceived` event. It does not mean C# `async` / `await`.
 
-- Serial open, read/write, and raw receive (`Communicator` + `SerialPort`)
-- Built-in `HexProtocolAnalyzer` (binary frames) and `TextProtocolAnalyzer` (begin/end text frames)
-- Several protocols on one port; each analyzer maps a frame to your model
-- Optional checksums: text `CheckData` (for example NMEA XOR); hex 1-byte or 2-byte (`CheckData` / `CheckData16`)
-- With `Handshake.None`, RTS/DTR default high so some no-handshake devices can answer `Write`
+## Requirements
 
-## Requirements and versioning
+The current version requires the [.NET 8 SDK](https://dotnet.microsoft.com/download). Version 2.0.0 changes the target framework.
 
-The current mainline needs the [.NET 8 SDK](https://dotnet.microsoft.com/download). 2.0.0 is an intentional major-version break.
-
-| Line | Target | Where to get it |
+| Version | Target | How to get it |
 | --- | --- | --- |
-| **1.x** | .NET Framework 3.5 | Tag [`v1.1.0`](https://github.com/PeterRock/KoboldCom/releases/tag/v1.1.0). If you also need the later 2-byte hex checksum and Handshake.None RTS/DTR work, use branch [`netfx-1.x`](https://github.com/PeterRock/KoboldCom/tree/netfx-1.x). Do not move a Framework app to 2.x. |
-| **2.x** (current) | `net8.0` + NuGet `System.IO.Ports` | Current `master`, assembly version **2.0.0**. Includes the 1.x protocol/serial behavior above. Framework 3.5 projects cannot reference 2.x. |
+| **1.x** | .NET Framework 3.5 | Tag [`v1.1.0`](https://github.com/PeterRock/KoboldCom/releases/tag/v1.1.0). For the later 2-byte hex checksum and RTS/DTR behavior when `Handshake` is `None`, use branch [`netfx-1.x`](https://github.com/PeterRock/KoboldCom/tree/netfx-1.x). Do not upgrade a Framework project to 2.x. |
+| **2.x** (current) | `net8.0` + NuGet `System.IO.Ports` | Current `master`. Assembly version **2.0.0**. Includes the 1.x protocol and serial behavior listed above. A .NET Framework 3.5 project cannot reference 2.x. |
 
-The public C# API and Chinese XML docs are kept as stable as practical. See [CHANGELOG.md](CHANGELOG.md) for the finer points.
+The public C# API and Chinese XML docs in 2.0.0 match 1.x. Protocol logic was not rewritten. See [CHANGELOG.md](CHANGELOG.md) for the full list of changes.
 
-Port names are still Windows-style `COM` + number (`SerialPortSetting.Port`). The Demo is `net8.0-windows` WinForms and runs on Windows only.
+A port name is `COM` plus the port number (`SerialPortSetting.Port`). The Demo targets `net8.0-windows`. The Demo runs on Windows only.
 
-## Quick start
+## Build
 
 ```bash
 dotnet build KoboldCom.sln
+```
 
+These checks do not need hardware:
+
+```bash
 dotnet run --project verify/TextProtocolAnalyzerCheckData
 dotnet run --project verify/HexProtocolAnalyzerCheckLength
 dotnet run --project verify/SerialPortHandshakeNone
 ```
 
-The three `verify` projects need no hardware. They cover text checksums, hex checksum length, and Handshake.None RTS/DTR defaults.
+The projects check text checksums, hex checksum length, and RTS/DTR defaults when `Handshake` is `None`.
 
-On Windows, open the Demo:
+Run the Demo on Windows:
 
 ```bash
 dotnet run --project Demo
 ```
 
-Non-Windows machines can cross-compile the Demo (`EnableWindowsTargeting` is on) but cannot run the UI. Full multi-protocol usage is in [`Demo/`](Demo/).
+Other systems can cross-compile the Demo (`EnableWindowsTargeting` is set) but cannot run the UI. Sample code is in [`Demo/`](Demo/).
 
-## Concepts
+## How it works
 
-The pipeline is:
+`Communicator` holds an `ICommunication` (usually `KoboldCom.SerialPort`) and an `IAnalyzerCollection`.
 
-`SerialPort.DataReceived` → `Communicator` reads bytes → each `IAnalyzer.SearchBuffer` cuts a frame → `Analyze()` maps the model
+Processing order:
 
-`Communicator` holds an `ICommunication` (usually `KoboldCom.SerialPort`) and an `IAnalyzerCollection`. Incoming bytes raise `OnRawDataReceived`, then every analyzer searches the buffer.
+1. `SerialPort.DataReceived` fires.
+2. `Communicator` reads the bytes.
+3. `Communicator` raises `OnRawDataReceived`.
+4. Each `IAnalyzer` in the collection calls `SearchBuffer`.
+5. After a complete frame is found, `Analyze()` runs.
 
-Subscribe to these two events in application code:
+A port can register more than one analyzer.
 
-| Event | On | When |
+## Usage
+
+### Events
+
+| Event | Type | When it runs |
 | --- | --- | --- |
-| `OnRawDataReceived` | `Communicator` | A chunk of raw bytes was just read |
-| `OnDataAnalyzed` | A concrete `ProtocolAnalyzer<T>` | The subclass sets `Valid = true` (or later timeout sets `Valid` back to `false`) |
+| `OnRawDataReceived` | `Communicator` | A chunk of raw bytes was read. |
+| `OnDataAnalyzed` | `ProtocolAnalyzer<T>` | The subclass sets `Valid` to `true`. After a timeout, `Valid` is set back to `false` and the event runs again. |
 
-`ICommunication.OnDataReceived` is the lower-level “bytes available” hook. `Communicator` already handles it.
+`ICommunication.OnDataReceived` means the port has bytes to read. `Communicator` already subscribes to that event.
 
 ```csharp
 var protocols = new MyProtocols();
@@ -75,34 +81,71 @@ protocols.ProtocolBinary.OnDataAnalyzed += m => { /* hex model */ };
 communicator.Com.Open(new SerialPortSetting { Port = 2, Baudrate = 9600 });
 ```
 
-`SerialPortSetting` defaults to `Handshake = None`, `RtsEnable = true`, and `DtrEnable = true`. Those flags are written when `Setting` is applied and again after `Open`. If `Handshake` is not `None`, the OS handshake owns the lines; the library does not write them, and the getter reports them inactive. Set a flag to `false` if that line must stay low.
+Set the frame format in the subclass constructor. In `Analyze()`, assign `Raw` to `Data`, then set `Valid = true`.
 
-## Protocols
+### Serial settings
 
-A typical binary frame looks like:
+`SerialPortSetting` defaults:
+
+- `Handshake = None`
+- `RtsEnable = true`
+- `DtrEnable = true`
+
+RTS/DTR are written when `Setting` is applied. They are written again after `Open`. If `Handshake` is not `None`, the library does not write those lines. Reading the settings then reports both as `false`. To keep a line low, set the matching property to `false`.
+
+### `TextProtocolAnalyzer`
+
+Frame format: `[BeginOfLine][payload][EndOfLine]`. If `CheckData` is set, a checksum follows: `[EndOfLine][check]`.
+
+- If `CheckData` is `null`, there is no checksum check. The Demo text protocol `^&100$$` does not set `CheckData`.
+- `EndOfLine` is searched after `BeginOfLine`.
+- A complete frame with a bad checksum is not a valid packet. That frame is removed from the buffer. A later valid frame can still match.
+- `CheckLength` defaults to 2, meaning two hex ASCII digits after `EndOfLine`. `CheckLength = 1` compares the next raw byte.
+
+See `verify/TextProtocolAnalyzerCheckData`.
+
+### `HexProtocolAnalyzer`
+
+Frame format: `[Mask][length][data][checksum]`.
+
+- `CheckLength` defaults to 1.
+- `CheckData` defaults to `XorCheck`.
+- For `CheckLength = 2`, set `CheckData16` (`Crc16Modbus` or `SumCheck16`). The compare is little-endian (low byte first) by default. For big-endian, set `CheckBigEndian = true`.
+- If `CheckData16` is not set, the 1-byte `CheckData` result is compared as a 16-bit value.
+- `CheckLength <= 0` means the frame has no checksum field.
+- For a fixed-length frame, set `StaticLength`.
+
+See `verify/HexProtocolAnalyzerCheckLength` and `Demo/DemoHexProtocol.cs`.
+
+### Custom protocols
+
+If the built-in analyzers do not apply, subclass `ProtocolAnalyzer<T>`.
+
+- Override `SearchBuffer`: copy one frame from the `List<byte>` into `Raw`, and remove the processed bytes from the buffer.
+- Override `Analyze()`: map `Raw` to the model.
+
+`HexProtocolAnalyzer` and `TextProtocolAnalyzer` already implement `SearchBuffer`. In that case, configure the subclass in the constructor and override `Analyze()`.
+
+Put more than one analyzer in an `IAnalyzerCollection`. Example: `Demo/MyProtocols.cs`.
+
+## Examples
+
+Binary frame:
 
 ```
 header + length + payload + checksum
 AA 44 05 01 02 03 04 05 EA
 ```
 
-A typical text sentence looks like:
+Text frame:
 
 ```
 $GPGGA,121252.000,3937.3032,N,11611.6046,E,1,05,2.0,45.9,M,-5.7,M,,0000*75
 ```
 
-`$` starts the sentence, `*` ends it, and `75` is the XOR of the characters between `$` and `*`. Those two shapes map to `HexProtocolAnalyzer` and `TextProtocolAnalyzer`. Configure framing in the subclass **constructor**, map `Raw` to `Data` in `Analyze()`, then set `Valid = true`.
+`$` is the start marker. `*` is the end marker. `75` is the XOR of the characters between `$` and `*`.
 
-### Text: `TextProtocolAnalyzer`
-
-Frame: `[BeginOfLine][payload][EndOfLine]`, optionally plus checksum: `[EndOfLine][check]`.
-
-- Leave `CheckData` unset for no checksum (the Demo `^&100$$` protocol does this)
-- `EndOfLine` is searched **after** `BeginOfLine`, so an earlier leftover terminator is ignored
-- A complete frame with a bad checksum is not a valid packet and is dropped from the buffer; a later good frame can still match
-
-NMEA-style `$...*HH`:
+NMEA (`$...*HH`):
 
 ```csharp
 public class NmeaProtocol : TextProtocolAnalyzer<MyModel>
@@ -111,18 +154,14 @@ public class NmeaProtocol : TextProtocolAnalyzer<MyModel>
     {
         BeginOfLine = "$";
         EndOfLine = "*";
-        CheckData = XorCheck; // CheckLength defaults to 2 hex ASCII digits after *
+        CheckData = XorCheck; // CheckLength defaults to 2
     }
 
     public override void Analyze() { /* Raw → Data; Valid = true; */ }
 }
 ```
 
-`CheckLength = 1` compares one raw byte after `EndOfLine`. Edge cases live in `verify/TextProtocolAnalyzerCheckData`.
-
-### Hex: `HexProtocolAnalyzer`
-
-Frame: `[Mask][length][data][checksum]`. Defaults are `CheckLength = 1` and `CheckData = XorCheck`, so existing 1-byte XOR/SUM protocols stay the same.
+Hex with a 1-byte sum:
 
 ```csharp
 public class DemoHex : HexProtocolAnalyzer<DemoDataModel>
@@ -130,47 +169,30 @@ public class DemoHex : HexProtocolAnalyzer<DemoDataModel>
     public DemoHex()
     {
         Mask = new byte[] { 0xAA, 0xBB, 0xCC };
-        CheckData = SumCheck; // still a 1-byte trailer by default
+        CheckData = SumCheck; // CheckLength defaults to 1
     }
 
     public override void Analyze() { /* Raw → Data; Valid = true; */ }
 }
 ```
 
-For a 2-byte checksum, set this in the subclass constructor:
+Hex with a 2-byte checksum (set this in the subclass constructor):
 
 ```csharp
 CheckLength = 2;
-CheckData16 = Crc16Modbus; // or SumCheck16; returns a 16-bit host value
-// Compared little-endian (low byte first) by default, matching Modbus CRC-16
-// High byte first: CheckBigEndian = true;
+CheckData16 = Crc16Modbus; // or SumCheck16
+// Little-endian by default. Big-endian: CheckBigEndian = true;
 ```
-
-If `CheckData16` is unset, the 1-byte `CheckData` result is compared as a 16-bit value. `CheckLength <= 0` means the frame has no checksum field. Use `StaticLength` for fixed-length frames. Details: `verify/HexProtocolAnalyzerCheckLength` and `Demo/DemoHexProtocol.cs`.
-
-## Extending
-
-If neither built-in analyzer fits, subclass abstract `ProtocolAnalyzer<T>`:
-
-- Override `SearchBuffer` to cut one frame from the `List<byte>` into `Raw`, and remove consumed bytes from the buffer
-- Implement `Analyze()` for the model mapping
-
-`HexProtocolAnalyzer` and `TextProtocolAnalyzer` already implement `SearchBuffer`. Most apps only set framing/checksums and override `Analyze()`. Put several analyzers in your own `IAnalyzerCollection` (see `Demo/MyProtocols.cs`) to run them together.
 
 ## Demo
 
 ![Demo screenshot](docs/Screen01.png)
 
-The WinForms sample runs the text protocol `^&…$$` and the hex protocol `AA BB CC …` at the same time, and lists `OnDataAnalyzed` results. Source: [`Demo/`](Demo/).
+The Demo is a WinForms app. It parses the text protocol `^&…$$` and the hex protocol `AA BB CC …` and lists `OnDataAnalyzed` results. Source: [`Demo/`](Demo/).
 
-## Serial debug
+## Additional resources
 
-[Windows virtual serial ports and debugging](https://www.petershi.net/archives/2885)
-
-## Thanks
-
-The idea started from [this article](http://blog.csdn.net/wuyazhe/article/details/5598945).
-
-## License
-
-[MIT](LICENSE)
+- [CHANGELOG.md](CHANGELOG.md)
+- [Windows virtual serial ports and debugging](https://www.petershi.net/archives/2885)
+- [Original reference article](http://blog.csdn.net/wuyazhe/article/details/5598945)
+- [MIT license](LICENSE)

--- a/README.EN.md
+++ b/README.EN.md
@@ -167,10 +167,6 @@ The WinForms sample runs the text protocol `^&…$$` and the hex protocol `AA BB
 
 [Windows virtual serial ports and debugging](https://www.petershi.net/archives/2885)
 
-## TODO
-
-- i18n
-
 ## Thanks
 
 The idea started from [this article](http://blog.csdn.net/wuyazhe/article/details/5598945).

--- a/README.md
+++ b/README.md
@@ -167,10 +167,6 @@ WinForms 示例同时跑文本协议 `^&…$$` 和十六进制 `AA BB CC …`，
 
 [Windows 虚拟串口与调试](https://www.petershi.net/archives/2885)
 
-## 待办
-
-- i18n
-
 ## 致谢
 
 动手做这个库的灵感来自[这篇文章](http://blog.csdn.net/wuyazhe/article/details/5598945)。

--- a/README.md
+++ b/README.md
@@ -1,126 +1,180 @@
-### KoboldCom
+[English](README.EN.md)
 
-`KoboldCom`是一个串口通信类库，提供自定义多协议异步解析、数据模型转换等功能。
+# KoboldCom
 
-这里的「异步」指 `SerialPort.DataReceived` 事件驱动的收包与解析流水线，不是 C# 的 `async`/`await`。
+KoboldCom 是一个 C# 串口通信类库：把收包、多协议解析和数据模型映射收成一条流水线，用来快速实现常见十六进制 / 文本协议。
 
-封装最复杂的数据流异步收发，以及根据协议把接收的数据进行模型映射转换等功能。
+这里的「异步」指 `SerialPort.DataReceived` 事件驱动的收包与解析，**不是** C# 的 `async` / `await`。
 
-类库提供了常见的16进制字节流协议`(HexProtocolAnalyzer)`和文本字节串协议`(TextProtocolAnalyzer)`的解析，所以可以使用KoboldCom，快速实现指定协议的数据收发
+## 功能
 
-### 版本说明
+- 封装串口打开、读写与原始收包（`Communicator` + `SerialPort`）
+- 内置 `HexProtocolAnalyzer`（二进制帧）和 `TextProtocolAnalyzer`（起止符文本帧）
+- 同一端口上同时匹配多种协议，解析后映射到自己的数据模型
+- 可选校验：文本 `CheckData`（如 NMEA XOR）；十六进制 1 字节或 2 字节（`CheckData` / `CheckData16`）
+- `Handshake.None` 时默认拉高 RTS/DTR，避免部分无握手设备只收不回
 
-这是一次有意的主版本中断：
+## 要求与版本
 
-| 版本线 | 目标框架 | 说明 |
+当前主线需要 [.NET 8 SDK](https://dotnet.microsoft.com/download)。这是一次有意的主版本中断。
+
+| 版本线 | 目标框架 | 从哪里取 |
 | --- | --- | --- |
-| **1.x** | .NET Framework 3.5 | 标签 **`v1.1.0`** 是规划 2.0 时的 Framework 快照（含 PR #4 CheckData）。其后合并的 PR #5（十六进制双字节校验 / Handshake.None RTS/DTR）仍在 Framework 上，见分支 **`netfx-1.x`**。仍在 Framework 上的项目请使用该标签或分支，不要升级到 2.x。 |
-| **2.x**（当前主线） | `net8.0` + NuGet `System.IO.Ports` | SDK 风格工程，并包含 PR #4 / #5 的协议与串口行为。2.x 程序集无法被 .NET Framework 3.5 项目引用。程序集版本 **2.0.0**。 |
+| **1.x** | .NET Framework 3.5 | 标签 [`v1.1.0`](https://github.com/PeterRock/KoboldCom/releases/tag/v1.1.0)。若还需要其后的十六进制双字节校验与 Handshake.None RTS/DTR，请用分支 [`netfx-1.x`](https://github.com/PeterRock/KoboldCom/tree/netfx-1.x)。不要把 Framework 项目升到 2.x。 |
+| **2.x**（当前） | `net8.0` + NuGet `System.IO.Ports` | 当前 `master`，程序集版本 **2.0.0**。包含上述 1.x 协议 / 串口行为。Framework 3.5 项目无法引用 2.x。 |
 
-公开 C# API 与中文 XML 文档尽量保持不变。本现代化不改写协议逻辑。
+公开 C# API 与中文 XML 文档尽量保持不变。更细的变更见 [CHANGELOG.md](CHANGELOG.md)。
 
-### 构建
+串口名仍按 Windows 习惯写成 `COM` + 端口号（`SerialPortSetting.Port`）。Demo 是 `net8.0-windows` WinForms，只能在 Windows 上运行。
 
-需要 [.NET 8 SDK](https://dotnet.microsoft.com/download)。
+## 快速开始
 
-```
+```bash
 dotnet build KoboldCom.sln
+
 dotnet run --project verify/TextProtocolAnalyzerCheckData
 dotnet run --project verify/HexProtocolAnalyzerCheckLength
 dotnet run --project verify/SerialPortHandshakeNone
 ```
 
-Demo 为 `net8.0-windows` WinForms 项目，请在 Windows 上运行。非 Windows 环境可以交叉编译（工程已开启 `EnableWindowsTargeting`），但不能运行该界面程序。
+三个 `verify` 项目不需要真实硬件，用来核对文本校验、十六进制校验长度，以及 Handshake.None 下的 RTS/DTR 默认值。
 
-### Wiki How
+在 Windows 上打开 Demo：
 
-常见的通讯协议一般是这样的：头+数据长度+数据正文+校验
-
-    AA 44 05 01 02 03 04 05 EA
-
-还有一种长这个样子：
-
-    $GPGGA,121252.000,3937.3032,N,11611.6046,E,1,05,2.0,45.9,M,-5.7,M,,0000*75
-
-其中$表示开始；GPGGA：命令字；*表示结尾;75校验（`$` 与 `*` 之间字符的异或）
-
-这两种协议很常见，所以KoboldCom默认提供了这两种常用的协议解析类（`HexProtocolAnalyzer`类和`TextProtocolAnalyzer`类）。
-
-文本协议可按与十六进制协议相同的方式可选启用 `CheckData`。在子类构造函数中配置，NMEA 风格（`$` 开始、`*` 结束、两位十六进制 XOR）示例：
-
-```
-BeginOfLine = "$";
-EndOfLine = "*";
-CheckData = XorCheck; // 默认读取 * 后 2 位十六进制，与 $ 和 * 之间字符的异或比较
+```bash
+dotnet run --project Demo
 ```
 
-不设置 `CheckData` 时不做校验（例如 Demo 的 `^&...$$`）。`EndOfLine` 从 `BeginOfLine` 之后查找，避免缓冲区里靠前的结束符被误用。
-校验失败的完整帧不会当作有效数据包，并从缓冲区丢弃；若其后还有合法帧，会继续匹配。
-`CheckLength` 默认为 2（十六进制 ASCII）；设为 1 时按 `EndOfLine` 后的单字节二进制校验比较。
+非 Windows 环境可以交叉编译 Demo（工程已开启 `EnableWindowsTargeting`），但不能运行该界面。完整多协议用法见 [`Demo/`](Demo/)。
 
-十六进制协议默认仍是帧尾 **1 字节**校验（`XorCheck`），现有协议无需改动。双字节校验时在子类构造函数中设置：
+## 概念
+
+流水线是：
+
+`SerialPort.DataReceived` → `Communicator` 读入字节 → 各 `IAnalyzer.SearchBuffer` 切帧 → `Analyze()` 映射模型
+
+`Communicator` 持有一个 `ICommunication`（通常是 `KoboldCom.SerialPort`）和一个 `IAnalyzerCollection`。收到字节后先触发 `OnRawDataReceived`，再让集合里的每个解析器搜索缓冲区。
+
+上层通常订阅这两个事件：
+
+| 事件 | 在哪里 | 何时触发 |
+| --- | --- | --- |
+| `OnRawDataReceived` | `Communicator` | 串口刚读到一批原始字节 |
+| `OnDataAnalyzed` | 具体的 `ProtocolAnalyzer<T>` | 子类把 `Valid = true`（或之后超时把 `Valid` 置回 `false`） |
+
+`ICommunication.OnDataReceived` 是更底层的「有数据可读」钩子，`Communicator` 已经接好，一般不必再订。
+
+```csharp
+var protocols = new MyProtocols();
+var communicator = new Communicator(new KoboldCom.SerialPort(), protocols);
+
+communicator.OnRawDataReceived += bytes => { /* 原始字节 */ };
+protocols.ProtocolText.OnDataAnalyzed += m => { /* 文本模型 */ };
+protocols.ProtocolBinary.OnDataAnalyzed += m => { /* 十六进制模型 */ };
+
+communicator.Com.Open(new SerialPortSetting { Port = 2, Baudrate = 9600 });
+```
+
+`SerialPortSetting` 默认 `Handshake = None`、`RtsEnable = true`、`DtrEnable = true`，在应用 `Setting` 以及 `Open` 之后写入端口。`Handshake` 不是 `None` 时这两根线仍由系统握手逻辑控制，不会被改写；读取时也显示为未拉高。需要某根线保持低电平，把对应标志设为 `false`。
+
+## 协议
+
+常见帧长这样：
 
 ```
+头 + 长度 + 正文 + 校验
+AA 44 05 01 02 03 04 05 EA
+```
+
+或文本句：
+
+```
+$GPGGA,121252.000,3937.3032,N,11611.6046,E,1,05,2.0,45.9,M,-5.7,M,,0000*75
+```
+
+`$` 开始，`*` 结束，`75` 是 `$` 与 `*` 之间字符的异或。这两种形态分别对应 `HexProtocolAnalyzer` 和 `TextProtocolAnalyzer`。在子类**构造函数**里配置帧格式，在 `Analyze()` 里把 `Raw` 映射到 `Data`，再设 `Valid = true`。
+
+### 文本：`TextProtocolAnalyzer`
+
+帧形：`[BeginOfLine][正文][EndOfLine]`，可选再跟校验：`[EndOfLine][校验]`。
+
+- 不设 `CheckData` 则不做校验（Demo 的 `^&100$$` 就是这样）
+- `EndOfLine` 从 `BeginOfLine` **之后**查找，避免缓冲区里靠前的结束符被误用
+- 完整但校验失败的帧不会当作有效包，并从缓冲区丢掉；后面若还有合法帧会继续匹配
+
+NMEA 风格（`$...*HH`）：
+
+```csharp
+public class NmeaProtocol : TextProtocolAnalyzer<MyModel>
+{
+    public NmeaProtocol()
+    {
+        BeginOfLine = "$";
+        EndOfLine = "*";
+        CheckData = XorCheck; // CheckLength 默认 2：* 后两位十六进制 ASCII
+    }
+
+    public override void Analyze() { /* Raw → Data; Valid = true; */ }
+}
+```
+
+`CheckLength = 1` 时按 `EndOfLine` 后的单字节二进制比较。细节与边界情况见 `verify/TextProtocolAnalyzerCheckData`。
+
+### 十六进制：`HexProtocolAnalyzer`
+
+帧形：`[Mask][长度][数据][校验]`。默认 `CheckLength = 1`、`CheckData = XorCheck`，现有单字节 XOR/SUM 协议不用改。
+
+```csharp
+public class DemoHex : HexProtocolAnalyzer<DemoDataModel>
+{
+    public DemoHex()
+    {
+        Mask = new byte[] { 0xAA, 0xBB, 0xCC };
+        CheckData = SumCheck; // 默认仍是帧尾 1 字节
+    }
+
+    public override void Analyze() { /* Raw → Data; Valid = true; */ }
+}
+```
+
+双字节校验时，在子类构造函数中设置：
+
+```csharp
 CheckLength = 2;
 CheckData16 = Crc16Modbus; // 或 SumCheck16；返回 16 位主机数值
-// 默认按小端（低字节在前）与帧尾两字节比较，与 Modbus CRC-16 一致
-// 高字节在前时：CheckBigEndian = true;
+// 默认小端（低字节在前），与 Modbus CRC-16 一致
+// 高字节在前：CheckBigEndian = true;
 ```
 
-未设置 `CheckData16` 时，会把原来的单字节 `CheckData` 结果当作 16 位值比较。
+未设置 `CheckData16` 时，会把原来的单字节 `CheckData` 结果当作 16 位值比较。`CheckLength <= 0` 表示帧里没有校验段。定长帧用 `StaticLength`。细节见 `verify/HexProtocolAnalyzerCheckLength` 和 `Demo/DemoHexProtocol.cs`。
 
-### 串口 RTS / DTR
+## 扩展
 
-`Handshake.None` 时，系统不会自动驱动 RTS/DTR。`SerialPortSetting` 默认 `RtsEnable = true`、`DtrEnable = true`，在 `Open` / 应用 `Setting` 时写入端口，避免部分设备只能被动收数、`Write` 后无应答。需要关闭时把对应标志设为 `false`。`Handshake` 不为 `None` 时仍由系统握手逻辑控制，不会改写这两根线。
+内置两种解析器不够时，继承抽象类 `ProtocolAnalyzer<T>`：
 
-### Demo
-![运行截图](/docs/Screen01.png)
+- 一般只需要重写 `SearchBuffer`：从 `List<byte>` 里切出一帧写到 `Raw`，并视情况从缓冲区删掉已消费字节
+- 再实现 `Analyze()` 做模型转换
 
-### Code Demo
-可直接参考`/Demo`中的例子，包含完整的多协议处理
+`HexProtocolAnalyzer` / `TextProtocolAnalyzer` 已经实现了 `SearchBuffer`，多数项目只需配帧头、校验并重写 `Analyze()`。多个解析器放进自己的 `IAnalyzerCollection`（见 `Demo/MyProtocols.cs`）即可同时工作。
 
-#### Usage 
-```
-// 创建通讯协议和模型转换方法
-// Protocol1.cs
-...Analyze(){
-    // 处理数据模型转换
-}
+## Demo
 
+![运行截图](docs/Screen01.png)
 
-// 创建通讯器
-var communicator = new KoboldCom.Communicator(new KoboldCom.SerialPort(), new MyProtocols());
-// 通讯器处理接收原始数据
-communicator.OnRawDataReceived += Communicator_OnRawDataReceived;
-// 自定义模型转换后续操作
-Protocol1.OnDataAnalyzed += ProtocolText_OnDataAnalyzed;
-```
+WinForms 示例同时跑文本协议 `^&…$$` 和十六进制 `AA BB CC …`，并在列表里显示 `OnDataAnalyzed` 结果。源码在 [`Demo/`](Demo/)。
 
-### Events
+## 串口模拟与调试
 
-KoboldCom.Communicator对上层开放了两个事件
+[Windows 虚拟串口与调试](https://www.petershi.net/archives/2885)
 
-1. OnDataAnalyzed
-从串口接收的数据中解析到符合协议要求的数据包，会触发的事件
+## 待办
 
-2. OnDataReceived
-串口收到新数据，会触发该事件
-
-可以给这两个事件分别绑定处理方法就可以进行对应操作。
-
-### More
-如果这两种协议的解析方式不适合你的项目要求，可以继承抽象`ProtocolAnalyzer`类编写子类，一般只需要复写`SearchBuffer`方法,，也就是数据到协议的处理逻辑就可以了，其他的不需要改动。
-
-
-### TODO:
 - i18n
 
-### 串口模拟与调试
-[Windows](https://www.petershi.net/archives/2885)
+## 致谢
 
-### Thanks
-触发要做这个东西的灵感来自[文章](http://blog.csdn.net/wuyazhe/article/details/5598945)
+动手做这个库的灵感来自[这篇文章](http://blog.csdn.net/wuyazhe/article/details/5598945)。
 
+## 许可证
 
-### License
-MIT
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -2,67 +2,73 @@
 
 # KoboldCom
 
-KoboldCom 是一个 C# 串口通信类库：把收包、多协议解析和数据模型映射收成一条流水线，用来快速实现常见十六进制 / 文本协议。
+KoboldCom 是一个 C# 串口通信类库。它从串口读取字节，用一个或多个协议解析器切分数据帧，并把完整帧映射到数据模型。
 
-这里的「异步」指 `SerialPort.DataReceived` 事件驱动的收包与解析，**不是** C# 的 `async` / `await`。
+库包含 `HexProtocolAnalyzer`（二进制帧）和 `TextProtocolAnalyzer`（带起止标志的文本帧）。
 
-## 功能
+文档里的「异步」指 `SerialPort.DataReceived` 事件驱动的接收和解析。它不是 C# 的 `async` / `await`。
 
-- 封装串口打开、读写与原始收包（`Communicator` + `SerialPort`）
-- 内置 `HexProtocolAnalyzer`（二进制帧）和 `TextProtocolAnalyzer`（起止符文本帧）
-- 同一端口上同时匹配多种协议，解析后映射到自己的数据模型
-- 可选校验：文本 `CheckData`（如 NMEA XOR）；十六进制 1 字节或 2 字节（`CheckData` / `CheckData16`）
-- `Handshake.None` 时默认拉高 RTS/DTR，避免部分无握手设备只收不回
+## 要求
 
-## 要求与版本
+当前版本需要 [.NET 8 SDK](https://dotnet.microsoft.com/download)。2.0.0 更改了目标框架。
 
-当前主线需要 [.NET 8 SDK](https://dotnet.microsoft.com/download)。这是一次有意的主版本中断。
-
-| 版本线 | 目标框架 | 从哪里取 |
+| 版本 | 目标框架 | 获取方式 |
 | --- | --- | --- |
-| **1.x** | .NET Framework 3.5 | 标签 [`v1.1.0`](https://github.com/PeterRock/KoboldCom/releases/tag/v1.1.0)。若还需要其后的十六进制双字节校验与 Handshake.None RTS/DTR，请用分支 [`netfx-1.x`](https://github.com/PeterRock/KoboldCom/tree/netfx-1.x)。不要把 Framework 项目升到 2.x。 |
-| **2.x**（当前） | `net8.0` + NuGet `System.IO.Ports` | 当前 `master`，程序集版本 **2.0.0**。包含上述 1.x 协议 / 串口行为。Framework 3.5 项目无法引用 2.x。 |
+| **1.x** | .NET Framework 3.5 | 标签 [`v1.1.0`](https://github.com/PeterRock/KoboldCom/releases/tag/v1.1.0)。若还需要该标签之后的十六进制双字节校验，以及 `Handshake.None` 下的 RTS/DTR 行为，使用分支 [`netfx-1.x`](https://github.com/PeterRock/KoboldCom/tree/netfx-1.x)。不要把 Framework 项目升级到 2.x。 |
+| **2.x**（当前） | `net8.0` + NuGet `System.IO.Ports` | 当前 `master`。程序集版本 **2.0.0**。包含上表 1.x 的协议和串口行为。.NET Framework 3.5 项目不能引用 2.x。 |
 
-公开 C# API 与中文 XML 文档尽量保持不变。更细的变更见 [CHANGELOG.md](CHANGELOG.md)。
+2.0.0 的公开 C# API 和中文 XML 文档与 1.x 相同。协议逻辑没有改写。变更记录见 [CHANGELOG.md](CHANGELOG.md)。
 
-串口名仍按 Windows 习惯写成 `COM` + 端口号（`SerialPortSetting.Port`）。Demo 是 `net8.0-windows` WinForms，只能在 Windows 上运行。
+串口名格式为 `COM` 加端口号（`SerialPortSetting.Port`）。Demo 的目标框架是 `net8.0-windows`。Demo 只能在 Windows 上运行。
 
-## 快速开始
+## 构建
 
 ```bash
 dotnet build KoboldCom.sln
+```
 
+不接硬件时可以运行这些检查：
+
+```bash
 dotnet run --project verify/TextProtocolAnalyzerCheckData
 dotnet run --project verify/HexProtocolAnalyzerCheckLength
 dotnet run --project verify/SerialPortHandshakeNone
 ```
 
-三个 `verify` 项目不需要真实硬件，用来核对文本校验、十六进制校验长度，以及 Handshake.None 下的 RTS/DTR 默认值。
+这些项目分别检查文本校验、十六进制校验长度，以及 `Handshake.None` 时的 RTS/DTR 默认值。
 
-在 Windows 上打开 Demo：
+在 Windows 上运行 Demo：
 
 ```bash
 dotnet run --project Demo
 ```
 
-非 Windows 环境可以交叉编译 Demo（工程已开启 `EnableWindowsTargeting`），但不能运行该界面。完整多协议用法见 [`Demo/`](Demo/)。
+其他系统可以交叉编译 Demo（已设置 `EnableWindowsTargeting`），但不能运行该界面。示例代码在 [`Demo/`](Demo/)。
 
-## 概念
+## 工作方式
 
-流水线是：
+`Communicator` 持有一个 `ICommunication`（通常是 `KoboldCom.SerialPort`）和一个 `IAnalyzerCollection`。
 
-`SerialPort.DataReceived` → `Communicator` 读入字节 → 各 `IAnalyzer.SearchBuffer` 切帧 → `Analyze()` 映射模型
+处理顺序如下：
 
-`Communicator` 持有一个 `ICommunication`（通常是 `KoboldCom.SerialPort`）和一个 `IAnalyzerCollection`。收到字节后先触发 `OnRawDataReceived`，再让集合里的每个解析器搜索缓冲区。
+1. `SerialPort.DataReceived` 触发。
+2. `Communicator` 读取字节。
+3. `Communicator` 引发 `OnRawDataReceived`。
+4. 集合中的每个 `IAnalyzer` 调用 `SearchBuffer`。
+5. 找到完整帧后调用 `Analyze()`。
 
-上层通常订阅这两个事件：
+一个端口可以注册多个解析器。
 
-| 事件 | 在哪里 | 何时触发 |
+## 用法
+
+### 事件
+
+| 事件 | 类型 | 时机 |
 | --- | --- | --- |
-| `OnRawDataReceived` | `Communicator` | 串口刚读到一批原始字节 |
-| `OnDataAnalyzed` | 具体的 `ProtocolAnalyzer<T>` | 子类把 `Valid = true`（或之后超时把 `Valid` 置回 `false`） |
+| `OnRawDataReceived` | `Communicator` | 读到一批原始字节。 |
+| `OnDataAnalyzed` | `ProtocolAnalyzer<T>` | 子类将 `Valid` 设为 `true`。超时后 `Valid` 被设回 `false`，该事件也会触发。 |
 
-`ICommunication.OnDataReceived` 是更底层的「有数据可读」钩子，`Communicator` 已经接好，一般不必再订。
+`ICommunication.OnDataReceived` 表示端口上有可读数据。`Communicator` 已经订阅该事件。
 
 ```csharp
 var protocols = new MyProtocols();
@@ -75,34 +81,71 @@ protocols.ProtocolBinary.OnDataAnalyzed += m => { /* 十六进制模型 */ };
 communicator.Com.Open(new SerialPortSetting { Port = 2, Baudrate = 9600 });
 ```
 
-`SerialPortSetting` 默认 `Handshake = None`、`RtsEnable = true`、`DtrEnable = true`，在应用 `Setting` 以及 `Open` 之后写入端口。`Handshake` 不是 `None` 时这两根线仍由系统握手逻辑控制，不会被改写；读取时也显示为未拉高。需要某根线保持低电平，把对应标志设为 `false`。
+在子类构造函数中设置帧格式。在 `Analyze()` 中把 `Raw` 赋给 `Data`，然后设置 `Valid = true`。
 
-## 协议
+### 串口设置
 
-常见帧长这样：
+`SerialPortSetting` 的默认值：
+
+- `Handshake = None`
+- `RtsEnable = true`
+- `DtrEnable = true`
+
+应用 `Setting` 时写入 RTS/DTR。`Open` 之后再写一次。`Handshake` 不是 `None` 时，库不写这两根线；读取设置时这两项为 `false`。若某根线需要保持低电平，把对应属性设为 `false`。
+
+### `TextProtocolAnalyzer`
+
+帧格式：`[BeginOfLine][数据][EndOfLine]`。如果设置了 `CheckData`，帧末尾还有校验：`[EndOfLine][校验]`。
+
+- `CheckData` 为 `null` 时不做校验。Demo 文本协议 `^&100$$` 不设置 `CheckData`。
+- 在 `BeginOfLine` 之后查找 `EndOfLine`。
+- 完整但校验失败的帧不是有效包。该帧从缓冲区删除。之后的合法帧仍可匹配。
+- `CheckLength` 默认值为 2，表示 `EndOfLine` 后的两位十六进制 ASCII。`CheckLength = 1` 时比较后一个二进制字节。
+
+见 `verify/TextProtocolAnalyzerCheckData`。
+
+### `HexProtocolAnalyzer`
+
+帧格式：`[Mask][长度][数据][校验]`。
+
+- `CheckLength` 默认值为 1。
+- `CheckData` 默认值为 `XorCheck`。
+- `CheckLength = 2` 时使用 `CheckData16`（`Crc16Modbus` 或 `SumCheck16`）。比较默认小端（低字节在前）。大端时设置 `CheckBigEndian = true`。
+- 未设置 `CheckData16` 时，把单字节 `CheckData` 结果当作 16 位值比较。
+- `CheckLength <= 0` 表示没有校验段。
+- 定长帧使用 `StaticLength`。
+
+见 `verify/HexProtocolAnalyzerCheckLength` 和 `Demo/DemoHexProtocol.cs`。
+
+### 自定义协议
+
+若内置解析器不适用，继承 `ProtocolAnalyzer<T>`。
+
+- 重写 `SearchBuffer`：从 `List<byte>` 取出一帧写入 `Raw`，并从缓冲区删除已处理的字节。
+- 重写 `Analyze()`：把 `Raw` 映射到模型。
+
+`HexProtocolAnalyzer` 和 `TextProtocolAnalyzer` 已经实现 `SearchBuffer`。这种情况下只需在构造函数中配置，并重写 `Analyze()`。
+
+把多个解析器放在一个 `IAnalyzerCollection` 中。示例：`Demo/MyProtocols.cs`。
+
+## 示例
+
+二进制帧：
 
 ```
-头 + 长度 + 正文 + 校验
+头 + 长度 + 数据 + 校验
 AA 44 05 01 02 03 04 05 EA
 ```
 
-或文本句：
+文本帧：
 
 ```
 $GPGGA,121252.000,3937.3032,N,11611.6046,E,1,05,2.0,45.9,M,-5.7,M,,0000*75
 ```
 
-`$` 开始，`*` 结束，`75` 是 `$` 与 `*` 之间字符的异或。这两种形态分别对应 `HexProtocolAnalyzer` 和 `TextProtocolAnalyzer`。在子类**构造函数**里配置帧格式，在 `Analyze()` 里把 `Raw` 映射到 `Data`，再设 `Valid = true`。
+`$` 是起始标志。`*` 是结束标志。`75` 是 `$` 与 `*` 之间字符的异或。
 
-### 文本：`TextProtocolAnalyzer`
-
-帧形：`[BeginOfLine][正文][EndOfLine]`，可选再跟校验：`[EndOfLine][校验]`。
-
-- 不设 `CheckData` 则不做校验（Demo 的 `^&100$$` 就是这样）
-- `EndOfLine` 从 `BeginOfLine` **之后**查找，避免缓冲区里靠前的结束符被误用
-- 完整但校验失败的帧不会当作有效包，并从缓冲区丢掉；后面若还有合法帧会继续匹配
-
-NMEA 风格（`$...*HH`）：
+NMEA（`$...*HH`）：
 
 ```csharp
 public class NmeaProtocol : TextProtocolAnalyzer<MyModel>
@@ -111,18 +154,14 @@ public class NmeaProtocol : TextProtocolAnalyzer<MyModel>
     {
         BeginOfLine = "$";
         EndOfLine = "*";
-        CheckData = XorCheck; // CheckLength 默认 2：* 后两位十六进制 ASCII
+        CheckData = XorCheck; // CheckLength 默认值为 2
     }
 
     public override void Analyze() { /* Raw → Data; Valid = true; */ }
 }
 ```
 
-`CheckLength = 1` 时按 `EndOfLine` 后的单字节二进制比较。细节与边界情况见 `verify/TextProtocolAnalyzerCheckData`。
-
-### 十六进制：`HexProtocolAnalyzer`
-
-帧形：`[Mask][长度][数据][校验]`。默认 `CheckLength = 1`、`CheckData = XorCheck`，现有单字节 XOR/SUM 协议不用改。
+十六进制，单字节和校验：
 
 ```csharp
 public class DemoHex : HexProtocolAnalyzer<DemoDataModel>
@@ -130,47 +169,30 @@ public class DemoHex : HexProtocolAnalyzer<DemoDataModel>
     public DemoHex()
     {
         Mask = new byte[] { 0xAA, 0xBB, 0xCC };
-        CheckData = SumCheck; // 默认仍是帧尾 1 字节
+        CheckData = SumCheck; // CheckLength 默认值为 1
     }
 
     public override void Analyze() { /* Raw → Data; Valid = true; */ }
 }
 ```
 
-双字节校验时，在子类构造函数中设置：
+十六进制，双字节校验（写在子类构造函数中）：
 
 ```csharp
 CheckLength = 2;
-CheckData16 = Crc16Modbus; // 或 SumCheck16；返回 16 位主机数值
-// 默认小端（低字节在前），与 Modbus CRC-16 一致
-// 高字节在前：CheckBigEndian = true;
+CheckData16 = Crc16Modbus; // 或 SumCheck16
+// 默认小端。大端：CheckBigEndian = true;
 ```
-
-未设置 `CheckData16` 时，会把原来的单字节 `CheckData` 结果当作 16 位值比较。`CheckLength <= 0` 表示帧里没有校验段。定长帧用 `StaticLength`。细节见 `verify/HexProtocolAnalyzerCheckLength` 和 `Demo/DemoHexProtocol.cs`。
-
-## 扩展
-
-内置两种解析器不够时，继承抽象类 `ProtocolAnalyzer<T>`：
-
-- 一般只需要重写 `SearchBuffer`：从 `List<byte>` 里切出一帧写到 `Raw`，并视情况从缓冲区删掉已消费字节
-- 再实现 `Analyze()` 做模型转换
-
-`HexProtocolAnalyzer` / `TextProtocolAnalyzer` 已经实现了 `SearchBuffer`，多数项目只需配帧头、校验并重写 `Analyze()`。多个解析器放进自己的 `IAnalyzerCollection`（见 `Demo/MyProtocols.cs`）即可同时工作。
 
 ## Demo
 
 ![运行截图](docs/Screen01.png)
 
-WinForms 示例同时跑文本协议 `^&…$$` 和十六进制 `AA BB CC …`，并在列表里显示 `OnDataAnalyzed` 结果。源码在 [`Demo/`](Demo/)。
+Demo 是 WinForms 程序。它同时解析文本协议 `^&…$$` 和十六进制协议 `AA BB CC …`，并在列表中显示 `OnDataAnalyzed` 的结果。源码在 [`Demo/`](Demo/)。
 
-## 串口模拟与调试
+## 相关链接
 
-[Windows 虚拟串口与调试](https://www.petershi.net/archives/2885)
-
-## 致谢
-
-动手做这个库的灵感来自[这篇文章](http://blog.csdn.net/wuyazhe/article/details/5598945)。
-
-## 许可证
-
-[MIT](LICENSE)
+- [CHANGELOG.md](CHANGELOG.md)
+- [Windows 虚拟串口与调试](https://www.petershi.net/archives/2885)
+- [最初参考的文章](http://blog.csdn.net/wuyazhe/article/details/5598945)
+- [MIT 许可证](LICENSE)

--- a/README.md
+++ b/README.md
@@ -2,73 +2,38 @@
 
 # KoboldCom
 
-KoboldCom 是一个 C# 串口通信类库。它从串口读取字节，用一个或多个协议解析器切分数据帧，并把完整帧映射到数据模型。
-
-库包含 `HexProtocolAnalyzer`（二进制帧）和 `TextProtocolAnalyzer`（带起止标志的文本帧）。
+KoboldCom 是一个 C# 串口通信类库。它打开串口、读写字节、按协议切分数据帧，并把完整帧映射到数据模型。一个端口可以同时使用多个协议。
 
 文档里的「异步」指 `SerialPort.DataReceived` 事件驱动的接收和解析。它不是 C# 的 `async` / `await`。
 
 ## 要求
 
-当前版本需要 [.NET 8 SDK](https://dotnet.microsoft.com/download)。2.0.0 更改了目标框架。
+当前版本需要 [.NET 8 SDK](https://dotnet.microsoft.com/download)。
 
 | 版本 | 目标框架 | 获取方式 |
 | --- | --- | --- |
-| **1.x** | .NET Framework 3.5 | 标签 [`v1.1.0`](https://github.com/PeterRock/KoboldCom/releases/tag/v1.1.0)。若还需要该标签之后的十六进制双字节校验，以及 `Handshake.None` 下的 RTS/DTR 行为，使用分支 [`netfx-1.x`](https://github.com/PeterRock/KoboldCom/tree/netfx-1.x)。不要把 Framework 项目升级到 2.x。 |
-| **2.x**（当前） | `net8.0` + NuGet `System.IO.Ports` | 当前 `master`。程序集版本 **2.0.0**。包含上表 1.x 的协议和串口行为。.NET Framework 3.5 项目不能引用 2.x。 |
+| **1.x** | .NET Framework 3.5 | 标签 [`v1.1.0`](https://github.com/PeterRock/KoboldCom/releases/tag/v1.1.0)。之后的 Framework 提交在分支 [`netfx-1.x`](https://github.com/PeterRock/KoboldCom/tree/netfx-1.x)。不要把 Framework 项目升级到 2.x。 |
+| **2.x**（当前） | `net8.0` + NuGet `System.IO.Ports` | 当前 `master`。程序集版本 **2.0.0**。.NET Framework 3.5 项目不能引用 2.x。 |
 
-2.0.0 的公开 C# API 和中文 XML 文档与 1.x 相同。协议逻辑没有改写。变更记录见 [CHANGELOG.md](CHANGELOG.md)。
+变更记录见 [CHANGELOG.md](CHANGELOG.md)。
 
-串口名格式为 `COM` 加端口号（`SerialPortSetting.Port`）。Demo 的目标框架是 `net8.0-windows`。Demo 只能在 Windows 上运行。
+## 组成
 
-## 构建
+- `Communicator`：连接串口和解析器。读取字节，并分发给解析器。
+- `SerialPort`（实现 `ICommunication`）：打开、关闭、读写串口。
+- `ProtocolAnalyzer<T>`：把一帧映射到模型 `T`。内置 `HexProtocolAnalyzer` 和 `TextProtocolAnalyzer`。
+- `IAnalyzerCollection`：一组解析器。一个 `Communicator` 可以注册多个协议。
 
-```bash
-dotnet build KoboldCom.sln
-```
-
-不接硬件时可以运行这些检查：
-
-```bash
-dotnet run --project verify/TextProtocolAnalyzerCheckData
-dotnet run --project verify/HexProtocolAnalyzerCheckLength
-dotnet run --project verify/SerialPortHandshakeNone
-```
-
-这些项目分别检查文本校验、十六进制校验长度，以及 `Handshake.None` 时的 RTS/DTR 默认值。
-
-在 Windows 上运行 Demo：
-
-```bash
-dotnet run --project Demo
-```
-
-其他系统可以交叉编译 Demo（已设置 `EnableWindowsTargeting`），但不能运行该界面。示例代码在 [`Demo/`](Demo/)。
-
-## 工作方式
-
-`Communicator` 持有一个 `ICommunication`（通常是 `KoboldCom.SerialPort`）和一个 `IAnalyzerCollection`。
-
-处理顺序如下：
+处理顺序：
 
 1. `SerialPort.DataReceived` 触发。
-2. `Communicator` 读取字节。
-3. `Communicator` 引发 `OnRawDataReceived`。
-4. 集合中的每个 `IAnalyzer` 调用 `SearchBuffer`。
-5. 找到完整帧后调用 `Analyze()`。
-
-一个端口可以注册多个解析器。
+2. `Communicator` 读取字节，并引发 `OnRawDataReceived`。
+3. 集合中的每个解析器调用 `SearchBuffer`。
+4. 找到完整帧后调用 `Analyze()`。
 
 ## 用法
 
-### 事件
-
-| 事件 | 类型 | 时机 |
-| --- | --- | --- |
-| `OnRawDataReceived` | `Communicator` | 读到一批原始字节。 |
-| `OnDataAnalyzed` | `ProtocolAnalyzer<T>` | 子类将 `Valid` 设为 `true`。超时后 `Valid` 被设回 `false`，该事件也会触发。 |
-
-`ICommunication.OnDataReceived` 表示端口上有可读数据。`Communicator` 已经订阅该事件。
+创建 `IAnalyzerCollection`（见 `Demo/MyProtocols.cs`）。把它和 `SerialPort` 交给 `Communicator`。订阅事件。打开端口。
 
 ```csharp
 var protocols = new MyProtocols();
@@ -81,87 +46,43 @@ protocols.ProtocolBinary.OnDataAnalyzed += m => { /* 十六进制模型 */ };
 communicator.Com.Open(new SerialPortSetting { Port = 2, Baudrate = 9600 });
 ```
 
-在子类构造函数中设置帧格式。在 `Analyze()` 中把 `Raw` 赋给 `Data`，然后设置 `Valid = true`。
+在协议子类的构造函数中设置帧格式。在 `Analyze()` 中把 `Raw` 赋给 `Data`，然后设置 `Valid = true`。
 
-### 串口设置
+| 事件 | 类型 | 时机 |
+| --- | --- | --- |
+| `OnRawDataReceived` | `Communicator` | 读到一批原始字节。 |
+| `OnDataAnalyzed` | `ProtocolAnalyzer<T>` | 子类将 `Valid` 设为 `true`。超时后 `Valid` 被设回 `false`，该事件也会触发。 |
 
-`SerialPortSetting` 的默认值：
+`ICommunication.OnDataReceived` 表示端口上有可读数据。`Communicator` 已经订阅该事件。
 
-- `Handshake = None`
-- `RtsEnable = true`
-- `DtrEnable = true`
+串口名格式为 `COM` 加端口号（`SerialPortSetting.Port`）。`Handshake` 为 `None` 时，`RtsEnable` 和 `DtrEnable` 默认为 `true`，在应用 `Setting` 和 `Open` 之后写入。
 
-应用 `Setting` 时写入 RTS/DTR。`Open` 之后再写一次。`Handshake` 不是 `None` 时，库不写这两根线；读取设置时这两项为 `false`。若某根线需要保持低电平，把对应属性设为 `false`。
+### 文本协议
 
-### `TextProtocolAnalyzer`
-
-帧格式：`[BeginOfLine][数据][EndOfLine]`。如果设置了 `CheckData`，帧末尾还有校验：`[EndOfLine][校验]`。
-
-- `CheckData` 为 `null` 时不做校验。Demo 文本协议 `^&100$$` 不设置 `CheckData`。
-- 在 `BeginOfLine` 之后查找 `EndOfLine`。
-- 完整但校验失败的帧不是有效包。该帧从缓冲区删除。之后的合法帧仍可匹配。
-- `CheckLength` 默认值为 2，表示 `EndOfLine` 后的两位十六进制 ASCII。`CheckLength = 1` 时比较后一个二进制字节。
-
-见 `verify/TextProtocolAnalyzerCheckData`。
-
-### `HexProtocolAnalyzer`
-
-帧格式：`[Mask][长度][数据][校验]`。
-
-- `CheckLength` 默认值为 1。
-- `CheckData` 默认值为 `XorCheck`。
-- `CheckLength = 2` 时使用 `CheckData16`（`Crc16Modbus` 或 `SumCheck16`）。比较默认小端（低字节在前）。大端时设置 `CheckBigEndian = true`。
-- 未设置 `CheckData16` 时，把单字节 `CheckData` 结果当作 16 位值比较。
-- `CheckLength <= 0` 表示没有校验段。
-- 定长帧使用 `StaticLength`。
-
-见 `verify/HexProtocolAnalyzerCheckLength` 和 `Demo/DemoHexProtocol.cs`。
-
-### 自定义协议
-
-若内置解析器不适用，继承 `ProtocolAnalyzer<T>`。
-
-- 重写 `SearchBuffer`：从 `List<byte>` 取出一帧写入 `Raw`，并从缓冲区删除已处理的字节。
-- 重写 `Analyze()`：把 `Raw` 映射到模型。
-
-`HexProtocolAnalyzer` 和 `TextProtocolAnalyzer` 已经实现 `SearchBuffer`。这种情况下只需在构造函数中配置，并重写 `Analyze()`。
-
-把多个解析器放在一个 `IAnalyzerCollection` 中。示例：`Demo/MyProtocols.cs`。
-
-## 示例
-
-二进制帧：
-
-```
-头 + 长度 + 数据 + 校验
-AA 44 05 01 02 03 04 05 EA
-```
-
-文本帧：
-
-```
-$GPGGA,121252.000,3937.3032,N,11611.6046,E,1,05,2.0,45.9,M,-5.7,M,,0000*75
-```
-
-`$` 是起始标志。`*` 是结束标志。`75` 是 `$` 与 `*` 之间字符的异或。
-
-NMEA（`$...*HH`）：
+`TextProtocolAnalyzer` 的帧格式是 `[BeginOfLine][数据][EndOfLine]`。在 `BeginOfLine` 之后查找 `EndOfLine`。
 
 ```csharp
-public class NmeaProtocol : TextProtocolAnalyzer<MyModel>
+public class DemoText : TextProtocolAnalyzer<int>
 {
-    public NmeaProtocol()
+    public DemoText()
     {
-        BeginOfLine = "$";
-        EndOfLine = "*";
-        CheckData = XorCheck; // CheckLength 默认值为 2
+        BeginOfLine = "^&";
+        EndOfLine = "$$";
     }
 
-    public override void Analyze() { /* Raw → Data; Valid = true; */ }
+    public override void Analyze() { /* 从 Raw 解析数据；Valid = true; */ }
 }
 ```
 
-十六进制，单字节和校验：
+可选校验：设置 `CheckData` 后，帧末尾还有校验字段。`CheckLength` 默认值为 2（`EndOfLine` 后的两位十六进制 ASCII）。NMEA 示例：`BeginOfLine = "$"`，`EndOfLine = "*"`，`CheckData = XorCheck`。校验失败的完整帧会从缓冲区删除。
+
+### 十六进制协议
+
+`HexProtocolAnalyzer` 的帧格式是 `[Mask][长度][数据][校验]`。定长帧使用 `StaticLength`。
+
+```
+AA 44 05 01 02 03 04 05 EA
+```
 
 ```csharp
 public class DemoHex : HexProtocolAnalyzer<DemoDataModel>
@@ -169,26 +90,43 @@ public class DemoHex : HexProtocolAnalyzer<DemoDataModel>
     public DemoHex()
     {
         Mask = new byte[] { 0xAA, 0xBB, 0xCC };
-        CheckData = SumCheck; // CheckLength 默认值为 1
+        CheckData = SumCheck;
     }
 
     public override void Analyze() { /* Raw → Data; Valid = true; */ }
 }
 ```
 
-十六进制，双字节校验（写在子类构造函数中）：
+可选校验：`CheckLength` 默认值为 1，`CheckData` 默认值为 `XorCheck`。双字节校验时设置 `CheckLength = 2` 和 `CheckData16`（`Crc16Modbus` 或 `SumCheck16`）。比较默认小端。大端时设置 `CheckBigEndian = true`。
 
-```csharp
-CheckLength = 2;
-CheckData16 = Crc16Modbus; // 或 SumCheck16
-// 默认小端。大端：CheckBigEndian = true;
-```
+## 自定义协议
+
+若内置解析器不适用，继承 `ProtocolAnalyzer<T>`。
+
+- 重写 `SearchBuffer`：从 `List<byte>` 取出一帧写入 `Raw`，并删除已处理的字节。
+- 重写 `Analyze()`：把 `Raw` 映射到模型。
+
+`HexProtocolAnalyzer` 和 `TextProtocolAnalyzer` 已经实现 `SearchBuffer`。这种情况下只需配置帧格式并重写 `Analyze()`。
 
 ## Demo
 
 ![运行截图](docs/Screen01.png)
 
-Demo 是 WinForms 程序。它同时解析文本协议 `^&…$$` 和十六进制协议 `AA BB CC …`，并在列表中显示 `OnDataAnalyzed` 的结果。源码在 [`Demo/`](Demo/)。
+Demo 是 `net8.0-windows` WinForms 程序。它同时解析文本协议 `^&…$$` 和十六进制协议 `AA BB CC …`，并在列表中显示 `OnDataAnalyzed` 的结果。源码在 [`Demo/`](Demo/)。只能在 Windows 上运行：
+
+```bash
+dotnet run --project Demo
+```
+
+其他系统可以交叉编译 Demo（已设置 `EnableWindowsTargeting`），但不能运行该界面。
+
+## 构建
+
+```bash
+dotnet build KoboldCom.sln
+```
+
+无硬件检查：`dotnet run --project verify/TextProtocolAnalyzerCheckData`、`verify/HexProtocolAnalyzerCheckLength`、`verify/SerialPortHandshakeNone`。
 
 ## 相关链接
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rewrite `README.md` (Chinese, primary) and `README.EN.md` for current `master` (2.0.0 / `net8.0`). Both files use the same outline and plain Google developer-docs voice.

The main story is the library itself: serial I/O, multi-protocol frame parsing, and mapping to data models.

- Components: `Communicator`, `SerialPort` / `ICommunication`, `ProtocolAnalyzer` (Hex + Text), `IAnalyzerCollection`
- Day-to-day use: register protocols, subscribe events, implement `Analyze()`, open the port, run Demo
- Custom protocols: subclass `ProtocolAnalyzer` and override `SearchBuffer`

Checksums (`CheckData` / `CheckData16`), Handshake.None RTS/DTR, and the `verify/` projects are short notes. The 1.x / 2.x table stays compact (`v1.1.0`, `netfx-1.x`, current 2.0.0). Chinese ↔ English cross-links stay.

Docs only.

## Test plan

- [x] Skim both READMEs on GitHub (Chinese ↔ English link, screenshot, tables)
- [x] Confirm the core story leads, and checksum / RTS / verify text does not dominate
- [x] Confirm version pointers: `v1.1.0`, `netfx-1.x`, assembly 2.0.0 on `master`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7180b320-f3e5-4001-a5e1-707d2a3cdde9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7180b320-f3e5-4001-a5e1-707d2a3cdde9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

